### PR TITLE
feat: add reactive soundscapes foundation

### DIFF
--- a/src/character-creator/react/steps/class/class-selection-gallery-pane.test.ts
+++ b/src/character-creator/react/steps/class/class-selection-gallery-pane.test.ts
@@ -47,8 +47,8 @@ describe("ClassSelectionGalleryPane", () => {
     }));
 
     expect(markup).toContain("cc-class-selection-pane__intro");
-    expect(markup).toContain("cc-class-flow-vocations__eyebrow");
-    expect(markup).toContain("cc-class-flow-vocations__body");
+    expect(markup).toContain('data-class-selection-eyebrow="true"');
+    expect(markup).toContain('data-class-selection-body="true"');
     expect(markup).toContain("cc-class-selection-pane__gallery-scroll");
     expect(markup).toContain("cc-class-selection-pane__gallery-shadow");
     expect(markup).toContain("cc-class-selection-pane__gallery-inner");

--- a/src/character-creator/steps/step-background.test.ts
+++ b/src/character-creator/steps/step-background.test.ts
@@ -7,6 +7,7 @@ const loadPacksMock = vi.fn(async () => {});
 const getIndexedEntriesMock = vi.fn();
 const getCachedDescriptionMock = vi.fn();
 const fetchDocumentMock = vi.fn();
+const parseBackgroundAdvancementRequirementsMock = vi.fn();
 const parseBackgroundGrantsMock = vi.fn();
 const renderTemplateMock = vi.fn();
 const beginCardSelectionUpdateMock = vi.fn();
@@ -30,6 +31,7 @@ vi.mock("../data/compendium-indexer", () => ({
 }));
 
 vi.mock("../data/advancement-parser", () => ({
+  parseBackgroundAdvancementRequirements: parseBackgroundAdvancementRequirementsMock,
   parseBackgroundGrants: parseBackgroundGrantsMock,
 }));
 
@@ -125,6 +127,7 @@ beforeEach(() => {
   beginCardSelectionUpdateMock.mockReturnValue("request-1");
   isCurrentCardSelectionUpdateMock.mockReturnValue(true);
   patchCardDetailFromTemplateMock.mockResolvedValue(true);
+  parseBackgroundAdvancementRequirementsMock.mockResolvedValue([]);
   parseBackgroundGrantsMock.mockResolvedValue({
     skillProficiencies: ["arc", "his"],
     toolProficiency: "art:calligrapher",
@@ -244,7 +247,7 @@ describe("step background", () => {
         },
       }),
     );
-    expect(setDataSilent).toHaveBeenCalledWith({
+    expect(setDataSilent).toHaveBeenCalledWith(expect.objectContaining({
       uuid: "Compendium.background.sage",
       name: "Sage",
       img: "sage.png",
@@ -252,12 +255,13 @@ describe("step background", () => {
         skillProficiencies: ["arc", "his"],
         languageGrants: ["common"],
       }),
+      advancementRequirements: [],
       asi: { assignments: {} },
       languages: {
         fixed: ["common"],
         chosen: [],
       },
-    });
+    }));
 
     vi.clearAllMocks();
     fetchDocumentMock.mockRejectedValue(new Error("boom"));

--- a/src/fth-api.test.ts
+++ b/src/fth-api.test.ts
@@ -11,6 +11,12 @@ const openLevelUpWizardMock = vi.fn();
 const buildRotationApiMock = vi.fn(() => ({
   rotateAll: vi.fn(),
 }));
+const buildSoundscapeApiMock = vi.fn(() => ({
+  soundscapes: {
+    getLibrary: vi.fn(),
+    resolve: vi.fn(),
+  },
+}));
 
 vi.mock("./logger", () => ({
   MOD: "foundry-tabletop-helpers",
@@ -37,6 +43,10 @@ vi.mock("./window-rotation/index", () => ({
   buildRotationApi: buildRotationApiMock,
 }));
 
+vi.mock("./soundscapes/soundscape-api", () => ({
+  buildSoundscapeApi: buildSoundscapeApiMock,
+}));
+
 describe("fth api", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,6 +65,7 @@ describe("fth api", () => {
 
     expect(buildRotationApiMock).toHaveBeenCalledTimes(1);
     expect(buildCombatApiMock).toHaveBeenCalledTimes(1);
+    expect(buildSoundscapeApiMock).toHaveBeenCalledTimes(1);
     expect(api.version).toBe("1.2.3");
 
     api.setLevel("debug");
@@ -62,6 +73,8 @@ describe("fth api", () => {
     api.characterCreator();
     api.characterCreatorConfig();
     api.levelUp("actor-1");
+    api.soundscapes.getLibrary();
+    api.soundscapes.resolve();
 
     expect(setLevelMock).toHaveBeenCalledWith("debug");
     expect(openAssetManagerMock).toHaveBeenCalledTimes(1);

--- a/src/fth-api.ts
+++ b/src/fth-api.ts
@@ -8,8 +8,9 @@ import {
 } from "./character-creator/character-creator-init";
 import { getGame } from "./types";
 import { buildRotationApi, type FthRotationApi } from "./window-rotation/index";
+import { buildSoundscapeApi, type FthSoundscapeApi } from "./soundscapes/soundscape-api";
 
-export interface FthApi extends FthRotationApi, FthCombatApi {
+export interface FthApi extends FthRotationApi, FthCombatApi, FthSoundscapeApi {
   setLevel: (level: Level) => void;
   version?: string;
   assetManager: () => void;
@@ -28,6 +29,7 @@ export function buildFthApi(): FthApi {
     version: getFthVersion(),
     ...buildRotationApi(),
     ...buildCombatApi(),
+    ...buildSoundscapeApi(),
     assetManager: () => openAssetManager(),
     characterCreator: () => openCharacterCreatorWizard(),
     characterCreatorConfig: () => openGMConfigApp(),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,6 +36,7 @@ const registerCharacterCreatorSettingsMock = vi.fn();
 const registerCharacterCreatorHooksMock = vi.fn();
 const initCharacterCreatorReadyMock = vi.fn();
 const attachFthApiMock = vi.fn();
+const registerSoundscapeSettingsMock = vi.fn();
 
 vi.mock("./logger", () => ({
   MOD: "foundry-tabletop-helpers",
@@ -112,6 +113,10 @@ vi.mock("./fth-api", () => ({
   attachFthApi: attachFthApiMock,
 }));
 
+vi.mock("./soundscapes/soundscape-settings", () => ({
+  registerSoundscapeSettings: registerSoundscapeSettingsMock,
+}));
+
 describe("index shell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -160,6 +165,7 @@ describe("index shell", () => {
     expect(registerCombatSettingsMock).toHaveBeenCalledWith(settings);
     expect(registerAssetManagerSettingsMock).toHaveBeenCalledWith(settings);
     expect(registerCharacterCreatorSettingsMock).toHaveBeenCalledWith(settings);
+    expect(registerSoundscapeSettingsMock).toHaveBeenCalledWith(settings);
     expect(registerLPCSSheetMock).toHaveBeenCalledTimes(1);
     expect(preloadLPCSTemplatesMock).toHaveBeenCalledTimes(1);
     expect(registerInitiativeHooksMock).toHaveBeenCalledTimes(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   registerCharacterCreatorHooks,
   initCharacterCreatorReady,
 } from "./character-creator/character-creator-init";
+import { registerSoundscapeSettings } from "./soundscapes/soundscape-settings";
 
 interface SceneControlTool {
   name: string;
@@ -86,6 +87,9 @@ function onInit(): void {
   // Character Creator & Level-Up Manager
   if (settings) registerCharacterCreatorSettings(settings);
   registerCharacterCreatorHooks();
+
+  // Reactive Soundscapes foundation settings
+  if (settings) registerSoundscapeSettings(settings);
 
   registerAssetManagerSceneControlHook();
 

--- a/src/soundscapes/soundscape-accessors.test.ts
+++ b/src/soundscapes/soundscape-accessors.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MOD } from "../logger";
+import {
+  getSceneSoundscapeAssignment,
+  getStoredSoundscapeLibrarySnapshot,
+  getSoundscapeLibrarySnapshot,
+  getSoundscapeWorldDefaultProfileId,
+  resolveStoredSoundscapeState,
+  setSceneSoundscapeAssignment,
+  setSoundscapeLibrarySnapshot,
+  setSoundscapeWorldDefaultProfileId,
+} from "./soundscape-accessors";
+import { SOUNDSCAPE_FLAGS, SOUNDSCAPE_SETTINGS } from "./soundscape-settings-shared";
+
+describe("soundscape accessors", () => {
+  const originalGame = (globalThis as Record<string, unknown>).game;
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).game = originalGame;
+  });
+
+  it("round-trips the hidden world settings", async () => {
+    const store = new Map<string, unknown>();
+    (globalThis as Record<string, unknown>).game = {
+      version: "13.351",
+      system: { id: "dnd5e", version: "5.3.1" },
+      modules: new Map([[MOD, { version: "1.2.1", active: true, id: MOD }]]),
+      settings: {
+        get(module: string, key: string) {
+          return store.get(`${module}.${key}`);
+        },
+        async set(module: string, key: string, value: unknown) {
+          store.set(`${module}.${key}`, value);
+          return value;
+        },
+      },
+    };
+
+    await setSoundscapeLibrarySnapshot({
+      profiles: {
+        forest: {
+          id: "forest",
+          name: "Forest",
+          musicPrograms: {},
+          ambienceLayers: {},
+          soundMoments: {},
+          rules: [],
+        },
+      },
+    });
+    await setSoundscapeWorldDefaultProfileId("forest");
+
+    expect(getStoredSoundscapeLibrarySnapshot()).toMatchObject({
+      formatVersion: 1,
+      profiles: {
+        forest: {
+          id: "forest",
+        },
+      },
+    });
+    expect(getSoundscapeWorldDefaultProfileId()).toBe("forest");
+    expect(store.get(`${MOD}.${SOUNDSCAPE_SETTINGS.LIBRARY}`)).toEqual(expect.any(String));
+    expect(store.get(`${MOD}.${SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID}`)).toBe("forest");
+  });
+
+  it("falls back to an empty snapshot for invalid stored json", () => {
+    (globalThis as Record<string, unknown>).game = {
+      settings: {
+        get(module: string, key: string) {
+          if (module === MOD && key === SOUNDSCAPE_SETTINGS.LIBRARY) return "{bad";
+          return undefined;
+        },
+      },
+    };
+
+    expect(getStoredSoundscapeLibrarySnapshot()).toBeNull();
+    expect(getSoundscapeLibrarySnapshot().profiles).toEqual({});
+  });
+
+  it("falls back to an empty snapshot for unsupported stored snapshot versions", () => {
+    (globalThis as Record<string, unknown>).game = {
+      settings: {
+        get(module: string, key: string) {
+          if (module === MOD && key === SOUNDSCAPE_SETTINGS.LIBRARY) {
+            return JSON.stringify({
+              formatVersion: 999,
+              savedAt: "2026-03-27T00:00:00.000Z",
+              profiles: {},
+            });
+          }
+          return undefined;
+        },
+      },
+    };
+
+    expect(getStoredSoundscapeLibrarySnapshot()).toBeNull();
+    expect(getSoundscapeLibrarySnapshot().profiles).toEqual({});
+  });
+
+  it("reads and writes scene assignment flags", async () => {
+    const flags = new Map<string, unknown>();
+    const setFlagMock = vi.fn(async (_scope: string, key: string, value: unknown) => {
+      flags.set(key, value);
+      return value;
+    });
+    const unsetFlagMock = vi.fn(async (_scope: string, key: string) => {
+      flags.delete(key);
+      return true;
+    });
+    const scene = {
+      id: "scene-1",
+      getFlag(_scope: string, key: string) {
+        return flags.get(key);
+      },
+      setFlag: setFlagMock,
+      unsetFlag: unsetFlagMock,
+    };
+
+    await setSceneSoundscapeAssignment(scene, {
+      profileId: "forest",
+      overrides: {
+        musicProgramId: null,
+        ambienceLayerIds: ["birds"],
+      },
+    });
+
+    expect(getSceneSoundscapeAssignment(scene)).toEqual({
+      profileId: "forest",
+      overrides: {
+        musicProgramId: null,
+        ambienceLayerIds: ["birds"],
+      },
+    });
+
+    await setSceneSoundscapeAssignment(scene, null);
+
+    expect(unsetFlagMock).toHaveBeenCalledWith(MOD, SOUNDSCAPE_FLAGS.PROFILE_ID);
+    expect(unsetFlagMock).toHaveBeenCalledWith(MOD, SOUNDSCAPE_FLAGS.OVERRIDES);
+    expect(getSceneSoundscapeAssignment(scene)).toBeNull();
+  });
+
+  it("resolves against world default when a scene has no direct assignment", () => {
+    const store = new Map<string, unknown>();
+    store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID}`, "forest");
+    store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.LIBRARY}`, JSON.stringify({
+      formatVersion: 1,
+      savedAt: "2026-03-27T00:00:00.000Z",
+      profiles: {
+        forest: {
+          id: "forest",
+          name: "Forest",
+          musicPrograms: {
+            calm: {
+              id: "calm",
+              name: "Calm",
+              playlistUuids: ["Playlist.forest"],
+              selectionMode: "sequential",
+              delaySeconds: 0,
+            },
+          },
+          ambienceLayers: {},
+          soundMoments: {},
+          rules: [
+            {
+              id: "base",
+              trigger: { type: "base" },
+              musicProgramId: "calm",
+            },
+          ],
+        },
+      },
+    }));
+
+    (globalThis as Record<string, unknown>).game = {
+      settings: {
+        get(module: string, key: string) {
+          return store.get(`${module}.${key}`);
+        },
+      },
+      scenes: {
+        get: () => undefined,
+        find: () => undefined,
+      },
+    };
+
+    expect(resolveStoredSoundscapeState()).toMatchObject({
+      assignmentSource: "worldDefault",
+      profileId: "forest",
+      musicProgramId: "calm",
+    });
+  });
+
+  it("applies scene overrides when resolution falls back to the world default profile", () => {
+    const store = new Map<string, unknown>();
+    store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID}`, "forest");
+    store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.LIBRARY}`, JSON.stringify({
+      formatVersion: 1,
+      savedAt: "2026-03-27T00:00:00.000Z",
+      profiles: {
+        forest: {
+          id: "forest",
+          name: "Forest",
+          musicPrograms: {
+            calm: {
+              id: "calm",
+              name: "Calm",
+              playlistUuids: ["Playlist.calm"],
+              selectionMode: "sequential",
+              delaySeconds: 0,
+            },
+          },
+          ambienceLayers: {
+            birds: {
+              id: "birds",
+              name: "Birds",
+              mode: "loop",
+              soundUuids: ["PlaylistSound.birds"],
+              minDelaySeconds: 0,
+              maxDelaySeconds: 0,
+            },
+          },
+          soundMoments: {},
+          rules: [
+            {
+              id: "base",
+              trigger: { type: "base" },
+              musicProgramId: "calm",
+              ambienceLayerIds: ["birds"],
+            },
+          ],
+        },
+      },
+    }));
+
+    const flags = new Map<string, unknown>([
+      [SOUNDSCAPE_FLAGS.OVERRIDES, { musicProgramId: null }],
+    ]);
+
+    (globalThis as Record<string, unknown>).game = {
+      settings: {
+        get(module: string, key: string) {
+          return store.get(`${module}.${key}`);
+        },
+      },
+      scenes: {
+        get: () => undefined,
+        find: () => ({
+          id: "scene-1",
+          active: true,
+          getFlag(_scope: string, key: string) {
+            return flags.get(key);
+          },
+        }),
+      },
+    };
+
+    expect(resolveStoredSoundscapeState()).toMatchObject({
+      assignmentSource: "worldDefault",
+      profileId: "forest",
+      musicProgramId: null,
+      musicRuleId: "scene-override",
+      ambienceLayerIds: ["birds"],
+    });
+  });
+});

--- a/src/soundscapes/soundscape-accessors.ts
+++ b/src/soundscapes/soundscape-accessors.ts
@@ -1,0 +1,112 @@
+import { MOD } from "../logger";
+import { getGame, getSetting, setSetting } from "../types";
+import type {
+  PersistentSoundscapeLibrarySnapshot,
+  ResolvedSoundscapeState,
+  SoundscapeSceneAssignment,
+  SoundscapeTriggerContext,
+} from "./soundscape-types";
+import { SOUNDSCAPE_FLAGS, SOUNDSCAPE_SETTINGS } from "./soundscape-settings-shared";
+import {
+  createEmptySoundscapeLibrarySnapshot,
+  createPersistedSoundscapeLibrarySnapshot,
+  normalizeSoundscapeSceneAssignment,
+  parseStoredSoundscapeLibrarySnapshot,
+} from "./soundscape-normalization";
+import { resolveSoundscapeState } from "./soundscape-resolver";
+
+interface FlagDocumentLike {
+  id: string;
+  active?: boolean;
+  getFlag?: (scope: string, key: string) => unknown;
+  setFlag?: (scope: string, key: string, value: unknown) => Promise<unknown>;
+  unsetFlag?: (scope: string, key: string) => Promise<unknown>;
+}
+
+function parseLibrarySnapshot(raw: string | null | undefined): PersistentSoundscapeLibrarySnapshot | null {
+  if (!raw) return null;
+  try {
+    return parseStoredSoundscapeLibrarySnapshot(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function getSceneCollection(): { get(id: string): FlagDocumentLike | undefined; find(predicate: (item: FlagDocumentLike) => boolean): FlagDocumentLike | undefined } | null {
+  return (getGame()?.scenes as { get(id: string): FlagDocumentLike | undefined; find(predicate: (item: FlagDocumentLike) => boolean): FlagDocumentLike | undefined } | undefined) ?? null;
+}
+
+function hasSceneOverrides(overrides: SoundscapeSceneAssignment["overrides"]): boolean {
+  if (!overrides) return false;
+  return Object.prototype.hasOwnProperty.call(overrides, "musicProgramId")
+    || Object.prototype.hasOwnProperty.call(overrides, "ambienceLayerIds");
+}
+
+export function getStoredSoundscapeLibrarySnapshot(): PersistentSoundscapeLibrarySnapshot | null {
+  return parseLibrarySnapshot(getSetting<string>(MOD, SOUNDSCAPE_SETTINGS.LIBRARY) ?? "");
+}
+
+export function getSoundscapeLibrarySnapshot(): PersistentSoundscapeLibrarySnapshot {
+  return getStoredSoundscapeLibrarySnapshot() ?? createEmptySoundscapeLibrarySnapshot();
+}
+
+export async function setSoundscapeLibrarySnapshot(snapshot: unknown): Promise<void> {
+  const persisted = createPersistedSoundscapeLibrarySnapshot(snapshot);
+  await setSetting(MOD, SOUNDSCAPE_SETTINGS.LIBRARY, JSON.stringify(persisted));
+}
+
+export function getSoundscapeWorldDefaultProfileId(): string | null {
+  const raw = getSetting<string>(MOD, SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID) ?? "";
+  return raw.trim().length > 0 ? raw.trim() : null;
+}
+
+export async function setSoundscapeWorldDefaultProfileId(profileId: string | null): Promise<void> {
+  await setSetting(MOD, SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID, profileId ?? "");
+}
+
+export function getSceneSoundscapeAssignment(scene: FlagDocumentLike | null | undefined): SoundscapeSceneAssignment | null {
+  if (!scene?.getFlag) return null;
+  const profileId = scene.getFlag(MOD, SOUNDSCAPE_FLAGS.PROFILE_ID);
+  const overrides = scene.getFlag(MOD, SOUNDSCAPE_FLAGS.OVERRIDES);
+  const assignment = normalizeSoundscapeSceneAssignment({ profileId, overrides });
+  if (!assignment.profileId && !hasSceneOverrides(assignment.overrides)) return null;
+  return assignment;
+}
+
+export async function setSceneSoundscapeAssignment(scene: FlagDocumentLike, assignment: SoundscapeSceneAssignment | null): Promise<void> {
+  if (!scene.setFlag || !scene.unsetFlag) return;
+  const normalized = normalizeSoundscapeSceneAssignment(assignment ?? {});
+
+  if (normalized.profileId) {
+    await scene.setFlag(MOD, SOUNDSCAPE_FLAGS.PROFILE_ID, normalized.profileId);
+  } else {
+    await scene.unsetFlag(MOD, SOUNDSCAPE_FLAGS.PROFILE_ID);
+  }
+
+  if (hasSceneOverrides(normalized.overrides)) {
+    await scene.setFlag(MOD, SOUNDSCAPE_FLAGS.OVERRIDES, normalized.overrides);
+  } else {
+    await scene.unsetFlag(MOD, SOUNDSCAPE_FLAGS.OVERRIDES);
+  }
+}
+
+export function getSoundscapeSceneById(sceneId?: string): FlagDocumentLike | null {
+  const scenes = getSceneCollection();
+  if (!scenes) return null;
+  if (sceneId) return scenes.get(sceneId) ?? null;
+  return scenes.find((scene) => !!scene.active) ?? null;
+}
+
+export function resolveStoredSoundscapeState(
+  sceneId?: string,
+  context?: Partial<SoundscapeTriggerContext>,
+): ResolvedSoundscapeState | null {
+  const scene = getSoundscapeSceneById(sceneId);
+  return resolveSoundscapeState({
+    library: getSoundscapeLibrarySnapshot(),
+    sceneAssignment: getSceneSoundscapeAssignment(scene),
+    worldDefaultProfileId: getSoundscapeWorldDefaultProfileId(),
+    context,
+    sceneId: scene?.id ?? sceneId ?? null,
+  });
+}

--- a/src/soundscapes/soundscape-api.ts
+++ b/src/soundscapes/soundscape-api.ts
@@ -1,0 +1,20 @@
+import type { PersistentSoundscapeLibrarySnapshot, ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
+import { getStoredSoundscapeLibrarySnapshot, resolveStoredSoundscapeState } from "./soundscape-accessors";
+
+export interface FthSoundscapeDebugApi {
+  getLibrary: () => PersistentSoundscapeLibrarySnapshot | null;
+  resolve: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => ResolvedSoundscapeState | null;
+}
+
+export interface FthSoundscapeApi {
+  soundscapes: FthSoundscapeDebugApi;
+}
+
+export function buildSoundscapeApi(): FthSoundscapeApi {
+  return {
+    soundscapes: {
+      getLibrary: () => getStoredSoundscapeLibrarySnapshot(),
+      resolve: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => resolveStoredSoundscapeState(sceneId, context),
+    },
+  };
+}

--- a/src/soundscapes/soundscape-normalization.test.ts
+++ b/src/soundscapes/soundscape-normalization.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEmptySoundscapeLibrarySnapshot,
+  normalizeSoundscapeLibrarySnapshot,
+  normalizeSoundscapeSceneAssignment,
+  normalizeSoundscapeTriggerContext,
+  parseStoredSoundscapeLibrarySnapshot,
+} from "./soundscape-normalization";
+
+describe("soundscape normalization", () => {
+  it("creates an empty snapshot fallback", () => {
+    expect(createEmptySoundscapeLibrarySnapshot()).toMatchObject({
+      formatVersion: 1,
+      profiles: {},
+    });
+  });
+
+  it("normalizes malformed library data to safe defaults", () => {
+    const snapshot = normalizeSoundscapeLibrarySnapshot({
+      profiles: {
+        forest: {
+          name: "Forest",
+          musicPrograms: {
+            calm: {
+              playlistUuids: ["Playlist.one", "Playlist.one", 42],
+              selectionMode: "weird",
+              delaySeconds: -5,
+            },
+          },
+          ambienceLayers: {
+            birds: {
+              mode: "random",
+              soundUuids: ["PlaylistSound.one", "", "PlaylistSound.one"],
+              minDelaySeconds: 8,
+              maxDelaySeconds: 2,
+            },
+          },
+          soundMoments: {
+            sting: {
+              soundUuids: ["PlaylistSound.sting"],
+              selectionMode: "weird",
+            },
+          },
+          rules: [
+            {
+              trigger: { type: "weather", weatherKeys: ["rain", "", "rain"] },
+              musicProgramId: "calm",
+            },
+            {
+              trigger: { type: "timeOfDay", timeOfDay: "bad" },
+              ambienceLayerIds: null,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(snapshot.profiles.forest?.musicPrograms.calm).toMatchObject({
+      playlistUuids: ["Playlist.one"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    });
+    expect(snapshot.profiles.forest?.ambienceLayers.birds).toMatchObject({
+      soundUuids: ["PlaylistSound.one"],
+      minDelaySeconds: 8,
+      maxDelaySeconds: 8,
+    });
+    expect(snapshot.profiles.forest?.soundMoments.sting?.selectionMode).toBe("single");
+    expect(snapshot.profiles.forest?.rules[0]?.trigger).toEqual({
+      type: "weather",
+      weatherKeys: ["rain"],
+    });
+    expect(snapshot.profiles.forest?.rules[1]?.trigger).toEqual({
+      type: "timeOfDay",
+      timeOfDay: "day",
+    });
+  });
+
+  it("drops invalid rule references during normalization", () => {
+    const snapshot = normalizeSoundscapeLibrarySnapshot({
+      profiles: {
+        forest: {
+          id: "forest",
+          musicPrograms: {
+            calm: {
+              id: "calm",
+              name: "Calm",
+              playlistUuids: ["Playlist.calm"],
+              selectionMode: "sequential",
+              delaySeconds: 0,
+            },
+          },
+          ambienceLayers: {
+            birds: {
+              id: "birds",
+              name: "Birds",
+              mode: "loop",
+              soundUuids: ["PlaylistSound.birds"],
+              minDelaySeconds: 0,
+              maxDelaySeconds: 0,
+            },
+          },
+          soundMoments: {},
+          rules: [
+            {
+              id: "combat",
+              trigger: { type: "combat" },
+              musicProgramId: "missing-program",
+              ambienceLayerIds: ["birds", "missing-layer"],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(snapshot.profiles.forest?.rules[0]).toEqual({
+      id: "combat",
+      trigger: { type: "combat" },
+      ambienceLayerIds: ["birds"],
+    });
+  });
+
+  it("normalizes scene assignment and preserves explicit null overrides", () => {
+    expect(normalizeSoundscapeSceneAssignment({
+      profileId: "forest",
+      overrides: {
+        musicProgramId: null,
+        ambienceLayerIds: ["birds", "birds", ""],
+      },
+    })).toEqual({
+      profileId: "forest",
+      overrides: {
+        musicProgramId: null,
+        ambienceLayerIds: ["birds"],
+      },
+    });
+  });
+
+  it("normalizes trigger context defaults", () => {
+    expect(normalizeSoundscapeTriggerContext({
+      manualPreview: 1 as unknown as boolean,
+      weather: "rain",
+      timeOfDay: "weird" as unknown as "day",
+    })).toEqual({
+      manualPreview: true,
+      inCombat: false,
+      weather: "rain",
+      timeOfDay: null,
+    });
+  });
+
+  it("rejects unsupported stored snapshot versions", () => {
+    expect(parseStoredSoundscapeLibrarySnapshot({
+      formatVersion: 999,
+      savedAt: "2026-03-27T00:00:00.000Z",
+      profiles: {},
+    })).toBeNull();
+  });
+});

--- a/src/soundscapes/soundscape-normalization.ts
+++ b/src/soundscapes/soundscape-normalization.ts
@@ -1,0 +1,280 @@
+import { getGame } from "../types";
+import { MOD } from "../logger";
+import {
+  type PersistentSoundscapeLibrarySnapshot,
+  type SoundscapeAmbienceLayer,
+  type SoundscapeMomentMode,
+  type SoundscapeMusicProgram,
+  type SoundscapeProfile,
+  type SoundscapeRule,
+  type SoundscapeRuleTrigger,
+  type SoundscapeSceneAssignment,
+  type SoundscapeSceneOverrides,
+  type SoundscapeSelectionMode,
+  type SoundscapeSoundMoment,
+  type SoundscapeTimeOfDay,
+  type SoundscapeTriggerContext,
+  SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
+} from "./soundscape-types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function sanitizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function uniqueStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const strings = value
+    .map((entry) => sanitizeString(entry))
+    .filter((entry): entry is string => !!entry);
+  return [...new Set(strings)];
+}
+
+function normalizeNonNegativeNumber(value: unknown, fallback: number): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+function hasOwn(source: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(source, key);
+}
+
+export function createEmptySoundscapeLibrarySnapshot(): PersistentSoundscapeLibrarySnapshot {
+  return {
+    formatVersion: SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
+    savedAt: "",
+    moduleVersion: getGame()?.modules?.get(MOD)?.version ?? undefined,
+    foundryVersion: getGame()?.version ?? undefined,
+    systemId: getGame()?.system?.id ?? undefined,
+    systemVersion: getGame()?.system?.version ?? undefined,
+    profiles: {},
+  };
+}
+
+export function normalizeSoundscapeSelectionMode(raw: unknown): SoundscapeSelectionMode {
+  return raw === "random" ? "random" : "sequential";
+}
+
+export function normalizeSoundscapeMomentMode(raw: unknown): SoundscapeMomentMode {
+  return raw === "random" ? "random" : "single";
+}
+
+export function normalizeSoundscapeTimeOfDay(raw: unknown): SoundscapeTimeOfDay | null {
+  return raw === "day" || raw === "night" ? raw : null;
+}
+
+export function normalizeSoundscapeMusicProgram(raw: unknown, fallbackId = "music-program"): SoundscapeMusicProgram {
+  const parsed = isRecord(raw) ? raw : {};
+  return {
+    id: sanitizeString(parsed.id) ?? fallbackId,
+    name: sanitizeString(parsed.name) ?? "Untitled Music Program",
+    playlistUuids: uniqueStrings(parsed.playlistUuids),
+    selectionMode: normalizeSoundscapeSelectionMode(parsed.selectionMode),
+    delaySeconds: normalizeNonNegativeNumber(parsed.delaySeconds, 0),
+  };
+}
+
+export function normalizeSoundscapeAmbienceLayer(raw: unknown, fallbackId = "ambience-layer"): SoundscapeAmbienceLayer {
+  const parsed = isRecord(raw) ? raw : {};
+  const minDelaySeconds = normalizeNonNegativeNumber(parsed.minDelaySeconds, 0);
+  const maxDelayCandidate = normalizeNonNegativeNumber(parsed.maxDelaySeconds, minDelaySeconds);
+  return {
+    id: sanitizeString(parsed.id) ?? fallbackId,
+    name: sanitizeString(parsed.name) ?? "Untitled Ambience Layer",
+    mode: parsed.mode === "random" ? "random" : "loop",
+    soundUuids: uniqueStrings(parsed.soundUuids),
+    minDelaySeconds,
+    maxDelaySeconds: Math.max(minDelaySeconds, maxDelayCandidate),
+  };
+}
+
+export function normalizeSoundscapeSoundMoment(raw: unknown, fallbackId = "sound-moment"): SoundscapeSoundMoment {
+  const parsed = isRecord(raw) ? raw : {};
+  return {
+    id: sanitizeString(parsed.id) ?? fallbackId,
+    name: sanitizeString(parsed.name) ?? "Untitled Sound Moment",
+    soundUuids: uniqueStrings(parsed.soundUuids),
+    selectionMode: normalizeSoundscapeMomentMode(parsed.selectionMode),
+  };
+}
+
+export function normalizeSoundscapeRuleTrigger(raw: unknown): SoundscapeRuleTrigger {
+  const parsed = isRecord(raw) ? raw : {};
+  const type = sanitizeString(parsed.type);
+  if (type === "manualPreview") return { type };
+  if (type === "combat") return { type };
+  if (type === "weather") {
+    return {
+      type,
+      weatherKeys: uniqueStrings(parsed.weatherKeys),
+    };
+  }
+  if (type === "timeOfDay") {
+    const timeOfDay = normalizeSoundscapeTimeOfDay(parsed.timeOfDay);
+    return {
+      type,
+      timeOfDay: timeOfDay ?? "day",
+    };
+  }
+  return { type: "base" };
+}
+
+function normalizeOptionalMusicProgramId(raw: Record<string, unknown>): string | null | undefined {
+  if (!hasOwn(raw, "musicProgramId")) return undefined;
+  if (raw.musicProgramId === null) return null;
+  return sanitizeString(raw.musicProgramId);
+}
+
+function normalizeOptionalAmbienceLayerIds(raw: Record<string, unknown>): string[] | null | undefined {
+  if (!hasOwn(raw, "ambienceLayerIds")) return undefined;
+  if (raw.ambienceLayerIds === null) return null;
+  return uniqueStrings(raw.ambienceLayerIds);
+}
+
+export function normalizeSoundscapeRule(raw: unknown, fallbackId = "soundscape-rule"): SoundscapeRule {
+  const parsed = isRecord(raw) ? raw : {};
+  const musicProgramId = normalizeOptionalMusicProgramId(parsed);
+  const ambienceLayerIds = normalizeOptionalAmbienceLayerIds(parsed);
+
+  return {
+    id: sanitizeString(parsed.id) ?? fallbackId,
+    trigger: normalizeSoundscapeRuleTrigger(parsed.trigger),
+    ...(musicProgramId !== undefined ? { musicProgramId } : {}),
+    ...(ambienceLayerIds !== undefined ? { ambienceLayerIds } : {}),
+  };
+}
+
+export function normalizeSoundscapeProfile(raw: unknown, fallbackId = "soundscape-profile"): SoundscapeProfile {
+  const parsed = isRecord(raw) ? raw : {};
+  const musicProgramsRaw = isRecord(parsed.musicPrograms) ? parsed.musicPrograms : {};
+  const ambienceLayersRaw = isRecord(parsed.ambienceLayers) ? parsed.ambienceLayers : {};
+  const soundMomentsRaw = isRecord(parsed.soundMoments) ? parsed.soundMoments : {};
+  const rulesRaw = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+  const musicPrograms = Object.fromEntries(
+    Object.entries(musicProgramsRaw).map(([id, value]) => {
+      const normalized = normalizeSoundscapeMusicProgram(value, id);
+      return [normalized.id, normalized];
+    }),
+  );
+
+  const ambienceLayers = Object.fromEntries(
+    Object.entries(ambienceLayersRaw).map(([id, value]) => {
+      const normalized = normalizeSoundscapeAmbienceLayer(value, id);
+      return [normalized.id, normalized];
+    }),
+  );
+
+  const soundMoments = Object.fromEntries(
+    Object.entries(soundMomentsRaw).map(([id, value]) => {
+      const normalized = normalizeSoundscapeSoundMoment(value, id);
+      return [normalized.id, normalized];
+    }),
+  );
+
+  const validMusicProgramIds = new Set(Object.keys(musicPrograms));
+  const validAmbienceLayerIds = new Set(Object.keys(ambienceLayers));
+  const rules = rulesRaw.map((value, index) => {
+    const normalized = normalizeSoundscapeRule(value, `soundscape-rule-${index + 1}`);
+    const musicProgramId = normalized.musicProgramId !== undefined
+      ? (normalized.musicProgramId === null || validMusicProgramIds.has(normalized.musicProgramId)
+        ? normalized.musicProgramId
+        : undefined)
+      : undefined;
+    const ambienceLayerIds = normalized.ambienceLayerIds !== undefined
+      ? (normalized.ambienceLayerIds === null
+        ? null
+        : normalized.ambienceLayerIds.filter((id) => validAmbienceLayerIds.has(id)))
+      : undefined;
+    return {
+      id: normalized.id,
+      trigger: normalized.trigger,
+      ...(musicProgramId !== undefined ? { musicProgramId } : {}),
+      ...(ambienceLayerIds !== undefined ? { ambienceLayerIds } : {}),
+    };
+  });
+
+  return {
+    id: sanitizeString(parsed.id) ?? fallbackId,
+    name: sanitizeString(parsed.name) ?? "Untitled Soundscape",
+    musicPrograms,
+    ambienceLayers,
+    soundMoments,
+    rules,
+  };
+}
+
+export function normalizeSoundscapeLibrarySnapshot(raw: unknown): PersistentSoundscapeLibrarySnapshot {
+  const fallback = createEmptySoundscapeLibrarySnapshot();
+  const parsed = isRecord(raw) ? raw : {};
+  const profilesRaw = isRecord(parsed.profiles) ? parsed.profiles : {};
+  const profiles = Object.fromEntries(
+    Object.entries(profilesRaw).map(([id, value]) => {
+      const normalized = normalizeSoundscapeProfile(value, id);
+      return [normalized.id, normalized];
+    }),
+  );
+
+  return {
+    formatVersion: SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
+    savedAt: sanitizeString(parsed.savedAt) ?? fallback.savedAt,
+    moduleVersion: sanitizeString(parsed.moduleVersion) ?? fallback.moduleVersion,
+    foundryVersion: sanitizeString(parsed.foundryVersion) ?? fallback.foundryVersion,
+    systemId: sanitizeString(parsed.systemId) ?? fallback.systemId,
+    systemVersion: sanitizeString(parsed.systemVersion) ?? fallback.systemVersion,
+    profiles,
+  };
+}
+
+export function parseStoredSoundscapeLibrarySnapshot(raw: unknown): PersistentSoundscapeLibrarySnapshot | null {
+  if (!isRecord(raw)) return null;
+  if (raw.formatVersion !== SOUNDSCAPE_LIBRARY_FORMAT_VERSION) return null;
+  return normalizeSoundscapeLibrarySnapshot(raw);
+}
+
+export function normalizeSoundscapeSceneOverrides(raw: unknown): SoundscapeSceneOverrides | null {
+  const parsed = isRecord(raw) ? raw : {};
+  const musicProgramId = normalizeOptionalMusicProgramId(parsed);
+  const ambienceLayerIds = normalizeOptionalAmbienceLayerIds(parsed);
+  if (musicProgramId === undefined && ambienceLayerIds === undefined) return null;
+  return {
+    ...(musicProgramId !== undefined ? { musicProgramId } : {}),
+    ...(ambienceLayerIds !== undefined ? { ambienceLayerIds } : {}),
+  };
+}
+
+export function normalizeSoundscapeSceneAssignment(raw: unknown): SoundscapeSceneAssignment {
+  const parsed = isRecord(raw) ? raw : {};
+  return {
+    profileId: sanitizeString(parsed.profileId) ?? null,
+    overrides: normalizeSoundscapeSceneOverrides(parsed.overrides),
+  };
+}
+
+export function normalizeSoundscapeTriggerContext(raw: Partial<SoundscapeTriggerContext> | undefined): SoundscapeTriggerContext {
+  return {
+    manualPreview: !!raw?.manualPreview,
+    inCombat: !!raw?.inCombat,
+    weather: sanitizeString(raw?.weather) ?? null,
+    timeOfDay: normalizeSoundscapeTimeOfDay(raw?.timeOfDay),
+  };
+}
+
+export function createPersistedSoundscapeLibrarySnapshot(
+  raw: unknown,
+  savedAt = new Date().toISOString(),
+): PersistentSoundscapeLibrarySnapshot {
+  const normalized = normalizeSoundscapeLibrarySnapshot(raw);
+  return {
+    ...normalized,
+    savedAt,
+    moduleVersion: getGame()?.modules?.get(MOD)?.version ?? normalized.moduleVersion,
+    foundryVersion: getGame()?.version ?? normalized.foundryVersion,
+    systemId: getGame()?.system?.id ?? normalized.systemId,
+    systemVersion: getGame()?.system?.version ?? normalized.systemVersion,
+  };
+}

--- a/src/soundscapes/soundscape-resolver.test.ts
+++ b/src/soundscapes/soundscape-resolver.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSoundscapeState } from "./soundscape-resolver";
+import type { PersistentSoundscapeLibrarySnapshot } from "./soundscape-types";
+
+function makeLibrary(): PersistentSoundscapeLibrarySnapshot {
+  return {
+    formatVersion: 1,
+    savedAt: "2026-03-27T00:00:00.000Z",
+    profiles: {
+      forest: {
+        id: "forest",
+        name: "Forest",
+        musicPrograms: {
+          calm: {
+            id: "calm",
+            name: "Calm",
+            playlistUuids: ["Playlist.calm"],
+            selectionMode: "sequential",
+            delaySeconds: 0,
+          },
+          battle: {
+            id: "battle",
+            name: "Battle",
+            playlistUuids: ["Playlist.battle"],
+            selectionMode: "random",
+            delaySeconds: 5,
+          },
+        },
+        ambienceLayers: {
+          birds: {
+            id: "birds",
+            name: "Birds",
+            mode: "loop",
+            soundUuids: ["PlaylistSound.birds"],
+            minDelaySeconds: 0,
+            maxDelaySeconds: 0,
+          },
+          rain: {
+            id: "rain",
+            name: "Rain",
+            mode: "loop",
+            soundUuids: ["PlaylistSound.rain"],
+            minDelaySeconds: 0,
+            maxDelaySeconds: 0,
+          },
+        },
+        soundMoments: {
+          sting: {
+            id: "sting",
+            name: "Sting",
+            soundUuids: ["PlaylistSound.sting"],
+            selectionMode: "single",
+          },
+        },
+        rules: [
+          {
+            id: "base",
+            trigger: { type: "base" },
+            musicProgramId: "calm",
+            ambienceLayerIds: ["birds"],
+          },
+          {
+            id: "night",
+            trigger: { type: "timeOfDay", timeOfDay: "night" },
+            ambienceLayerIds: [],
+          },
+          {
+            id: "weather-rain",
+            trigger: { type: "weather", weatherKeys: ["rain"] },
+            ambienceLayerIds: ["rain"],
+          },
+          {
+            id: "combat",
+            trigger: { type: "combat" },
+            musicProgramId: "battle",
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe("soundscape resolver", () => {
+  it("resolves the base state", () => {
+    expect(resolveSoundscapeState({
+      library: makeLibrary(),
+      worldDefaultProfileId: "forest",
+    })).toMatchObject({
+      profileId: "forest",
+      musicProgramId: "calm",
+      ambienceLayerIds: ["birds"],
+      musicRuleId: "base",
+      ambienceRuleId: "base",
+    });
+  });
+
+  it("uses precedence and per-channel fallback independently", () => {
+    expect(resolveSoundscapeState({
+      library: makeLibrary(),
+      worldDefaultProfileId: "forest",
+      context: {
+        inCombat: true,
+        weather: "rain",
+        timeOfDay: "night",
+      },
+    })).toMatchObject({
+      musicProgramId: "battle",
+      musicRuleId: "combat",
+      ambienceLayerIds: ["rain"],
+      ambienceRuleId: "weather-rain",
+    });
+  });
+
+  it("supports explicit scene overrides for base fallback", () => {
+    expect(resolveSoundscapeState({
+      library: makeLibrary(),
+      sceneAssignment: {
+        profileId: "forest",
+        overrides: {
+          musicProgramId: null,
+        },
+      },
+    })).toMatchObject({
+      assignmentSource: "scene",
+      musicProgramId: null,
+      musicRuleId: "scene-override",
+      ambienceLayerIds: ["birds"],
+    });
+  });
+
+  it("falls back to world default when the scene profile is missing", () => {
+    expect(resolveSoundscapeState({
+      library: makeLibrary(),
+      sceneAssignment: {
+        profileId: "missing",
+      },
+      worldDefaultProfileId: "forest",
+    })).toMatchObject({
+      assignmentSource: "worldDefault",
+      profileId: "forest",
+    });
+  });
+
+  it("applies scene overrides even when the profile comes from world-default fallback", () => {
+    expect(resolveSoundscapeState({
+      library: makeLibrary(),
+      sceneAssignment: {
+        profileId: null,
+        overrides: {
+          musicProgramId: null,
+        },
+      },
+      worldDefaultProfileId: "forest",
+    })).toMatchObject({
+      assignmentSource: "worldDefault",
+      profileId: "forest",
+      musicProgramId: null,
+      musicRuleId: "scene-override",
+      ambienceLayerIds: ["birds"],
+    });
+  });
+
+  it("returns null when no profile can be resolved", () => {
+    expect(resolveSoundscapeState({
+      library: makeLibrary(),
+      worldDefaultProfileId: "missing",
+    })).toBeNull();
+  });
+});

--- a/src/soundscapes/soundscape-resolver.ts
+++ b/src/soundscapes/soundscape-resolver.ts
@@ -1,0 +1,160 @@
+import {
+  type ResolveSoundscapeStateInput,
+  type ResolvedSoundscapeState,
+  type SoundscapeAmbienceLayer,
+  type SoundscapeMusicProgram,
+  type SoundscapeProfile,
+  type SoundscapeRule,
+  type SoundscapeRuleTrigger,
+} from "./soundscape-types";
+import { normalizeSoundscapeTriggerContext } from "./soundscape-normalization";
+
+interface ChannelResolution<TValue> {
+  value: TValue;
+  ruleId: string | null;
+}
+
+function triggerMatches(trigger: SoundscapeRuleTrigger, context: ReturnType<typeof normalizeSoundscapeTriggerContext>): boolean {
+  switch (trigger.type) {
+    case "base":
+      return true;
+    case "manualPreview":
+      return context.manualPreview;
+    case "combat":
+      return context.inCombat;
+    case "weather":
+      return !!context.weather && trigger.weatherKeys.includes(context.weather);
+    case "timeOfDay":
+      return context.timeOfDay === trigger.timeOfDay;
+  }
+}
+
+function resolveBaseMusicCandidate(rules: SoundscapeRule[]): ChannelResolution<string | null> {
+  for (const rule of rules) {
+    if (rule.trigger.type !== "base") continue;
+    if (Object.prototype.hasOwnProperty.call(rule, "musicProgramId")) {
+      return { value: rule.musicProgramId ?? null, ruleId: rule.id };
+    }
+  }
+  return { value: null, ruleId: null };
+}
+
+function resolveBaseAmbienceCandidate(rules: SoundscapeRule[]): ChannelResolution<string[]> {
+  for (const rule of rules) {
+    if (rule.trigger.type !== "base") continue;
+    if (Object.prototype.hasOwnProperty.call(rule, "ambienceLayerIds")) {
+      return { value: rule.ambienceLayerIds ?? [], ruleId: rule.id };
+    }
+  }
+  return { value: [], ruleId: null };
+}
+
+function resolveMusicProgram(
+  rules: SoundscapeRule[],
+  context: ReturnType<typeof normalizeSoundscapeTriggerContext>,
+  sceneOverrideMusicProgramId: string | null | undefined,
+): ChannelResolution<string | null> {
+  let base = resolveBaseMusicCandidate(rules);
+  if (sceneOverrideMusicProgramId !== undefined) {
+    base = { value: sceneOverrideMusicProgramId, ruleId: "scene-override" };
+  }
+
+  for (const triggerType of ["manualPreview", "combat", "weather", "timeOfDay"] as const) {
+    for (const rule of rules) {
+      if (rule.trigger.type !== triggerType || !triggerMatches(rule.trigger, context)) continue;
+      if (Object.prototype.hasOwnProperty.call(rule, "musicProgramId")) {
+        return { value: rule.musicProgramId ?? null, ruleId: rule.id };
+      }
+    }
+  }
+
+  return base;
+}
+
+function resolveAmbienceLayers(
+  rules: SoundscapeRule[],
+  context: ReturnType<typeof normalizeSoundscapeTriggerContext>,
+  sceneOverrideAmbienceLayerIds: string[] | null | undefined,
+): ChannelResolution<string[]> {
+  let base = resolveBaseAmbienceCandidate(rules);
+  if (sceneOverrideAmbienceLayerIds !== undefined) {
+    base = { value: sceneOverrideAmbienceLayerIds ?? [], ruleId: "scene-override" };
+  }
+
+  for (const triggerType of ["manualPreview", "combat", "weather", "timeOfDay"] as const) {
+    for (const rule of rules) {
+      if (rule.trigger.type !== triggerType || !triggerMatches(rule.trigger, context)) continue;
+      if (Object.prototype.hasOwnProperty.call(rule, "ambienceLayerIds")) {
+        return { value: rule.ambienceLayerIds ?? [], ruleId: rule.id };
+      }
+    }
+  }
+
+  return base;
+}
+
+function chooseProfile(
+  input: ResolveSoundscapeStateInput,
+): { profile: SoundscapeProfile; assignmentSource: ResolvedSoundscapeState["assignmentSource"] } | null {
+  const sceneProfileId = input.sceneAssignment?.profileId ?? null;
+  if (sceneProfileId) {
+    const sceneProfile = input.library.profiles[sceneProfileId];
+    if (sceneProfile) {
+      return { profile: sceneProfile, assignmentSource: "scene" };
+    }
+  }
+
+  const worldDefaultProfileId = input.worldDefaultProfileId ?? null;
+  if (worldDefaultProfileId) {
+    const worldDefaultProfile = input.library.profiles[worldDefaultProfileId];
+    if (worldDefaultProfile) {
+      return { profile: worldDefaultProfile, assignmentSource: "worldDefault" };
+    }
+  }
+
+  return null;
+}
+
+function lookupMusicProgram(profile: SoundscapeProfile, musicProgramId: string | null): SoundscapeMusicProgram | null {
+  return musicProgramId ? (profile.musicPrograms[musicProgramId] ?? null) : null;
+}
+
+function lookupAmbienceLayers(profile: SoundscapeProfile, layerIds: string[]): SoundscapeAmbienceLayer[] {
+  return layerIds
+    .map((id) => profile.ambienceLayers[id])
+    .filter((layer): layer is SoundscapeAmbienceLayer => !!layer);
+}
+
+export function resolveSoundscapeState(input: ResolveSoundscapeStateInput): ResolvedSoundscapeState | null {
+  const selected = chooseProfile(input);
+  if (!selected) return null;
+
+  const context = normalizeSoundscapeTriggerContext(input.context);
+  const rules = selected.profile.rules;
+  const sceneOverrides = input.sceneAssignment?.overrides ?? null;
+
+  const musicResolution = resolveMusicProgram(
+    rules,
+    context,
+    sceneOverrides?.musicProgramId,
+  );
+  const ambienceResolution = resolveAmbienceLayers(
+    rules,
+    context,
+    sceneOverrides?.ambienceLayerIds,
+  );
+
+  return {
+    profileId: selected.profile.id,
+    assignmentSource: selected.assignmentSource,
+    sceneId: input.sceneId ?? null,
+    context,
+    musicProgramId: musicResolution.value,
+    musicProgram: lookupMusicProgram(selected.profile, musicResolution.value),
+    musicRuleId: musicResolution.ruleId,
+    ambienceLayerIds: ambienceResolution.value,
+    ambienceLayers: lookupAmbienceLayers(selected.profile, ambienceResolution.value),
+    ambienceRuleId: ambienceResolution.ruleId,
+    soundMoments: Object.values(selected.profile.soundMoments),
+  };
+}

--- a/src/soundscapes/soundscape-settings-shared.ts
+++ b/src/soundscapes/soundscape-settings-shared.ts
@@ -1,0 +1,9 @@
+export const SOUNDSCAPE_SETTINGS = {
+  LIBRARY: "rsLibrary",
+  WORLD_DEFAULT_PROFILE_ID: "rsWorldDefaultProfileId",
+} as const;
+
+export const SOUNDSCAPE_FLAGS = {
+  PROFILE_ID: "rsProfileId",
+  OVERRIDES: "rsOverrides",
+} as const;

--- a/src/soundscapes/soundscape-settings.ts
+++ b/src/soundscapes/soundscape-settings.ts
@@ -1,0 +1,22 @@
+import { MOD } from "../logger";
+import { SOUNDSCAPE_SETTINGS } from "./soundscape-settings-shared";
+
+export function registerSoundscapeSettings(settings: {
+  register(module: string, key: string, data: Record<string, unknown>): void;
+}): void {
+  settings.register(MOD, SOUNDSCAPE_SETTINGS.LIBRARY, {
+    scope: "world",
+    config: false,
+    type: String,
+    default: "",
+    restricted: true,
+  });
+
+  settings.register(MOD, SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID, {
+    scope: "world",
+    config: false,
+    type: String,
+    default: "",
+    restricted: true,
+  });
+}

--- a/src/soundscapes/soundscape-types.ts
+++ b/src/soundscapes/soundscape-types.ts
@@ -1,0 +1,127 @@
+export const SOUNDSCAPE_LIBRARY_FORMAT_VERSION = 1;
+
+export type SoundscapeUuid = string;
+export type SoundscapeSelectionMode = "sequential" | "random";
+export type SoundscapeLayerMode = "loop" | "random";
+export type SoundscapeMomentMode = "single" | "random";
+export type SoundscapeTimeOfDay = "day" | "night";
+export type SoundscapeTriggerKind = "base" | "manualPreview" | "combat" | "weather" | "timeOfDay";
+export type SoundscapeAssignmentSource = "scene" | "worldDefault";
+
+export interface SoundscapeMusicProgram {
+  id: string;
+  name: string;
+  playlistUuids: SoundscapeUuid[];
+  selectionMode: SoundscapeSelectionMode;
+  delaySeconds: number;
+}
+
+export interface SoundscapeAmbienceLayer {
+  id: string;
+  name: string;
+  mode: SoundscapeLayerMode;
+  soundUuids: SoundscapeUuid[];
+  minDelaySeconds: number;
+  maxDelaySeconds: number;
+}
+
+export interface SoundscapeSoundMoment {
+  id: string;
+  name: string;
+  soundUuids: SoundscapeUuid[];
+  selectionMode: SoundscapeMomentMode;
+}
+
+export interface SoundscapeBaseTrigger {
+  type: "base";
+}
+
+export interface SoundscapeManualPreviewTrigger {
+  type: "manualPreview";
+}
+
+export interface SoundscapeCombatTrigger {
+  type: "combat";
+}
+
+export interface SoundscapeWeatherTrigger {
+  type: "weather";
+  weatherKeys: string[];
+}
+
+export interface SoundscapeTimeOfDayTrigger {
+  type: "timeOfDay";
+  timeOfDay: SoundscapeTimeOfDay;
+}
+
+export type SoundscapeRuleTrigger =
+  | SoundscapeBaseTrigger
+  | SoundscapeManualPreviewTrigger
+  | SoundscapeCombatTrigger
+  | SoundscapeWeatherTrigger
+  | SoundscapeTimeOfDayTrigger;
+
+export interface SoundscapeRule {
+  id: string;
+  trigger: SoundscapeRuleTrigger;
+  musicProgramId?: string | null;
+  ambienceLayerIds?: string[] | null;
+}
+
+export interface SoundscapeProfile {
+  id: string;
+  name: string;
+  musicPrograms: Record<string, SoundscapeMusicProgram>;
+  ambienceLayers: Record<string, SoundscapeAmbienceLayer>;
+  soundMoments: Record<string, SoundscapeSoundMoment>;
+  rules: SoundscapeRule[];
+}
+
+export interface PersistentSoundscapeLibrarySnapshot {
+  formatVersion: typeof SOUNDSCAPE_LIBRARY_FORMAT_VERSION;
+  savedAt: string;
+  moduleVersion?: string;
+  foundryVersion?: string;
+  systemId?: string;
+  systemVersion?: string;
+  profiles: Record<string, SoundscapeProfile>;
+}
+
+export interface SoundscapeSceneOverrides {
+  musicProgramId?: string | null;
+  ambienceLayerIds?: string[] | null;
+}
+
+export interface SoundscapeSceneAssignment {
+  profileId: string | null;
+  overrides?: SoundscapeSceneOverrides | null;
+}
+
+export interface SoundscapeTriggerContext {
+  manualPreview: boolean;
+  inCombat: boolean;
+  weather: string | null;
+  timeOfDay: SoundscapeTimeOfDay | null;
+}
+
+export interface ResolvedSoundscapeState {
+  profileId: string;
+  assignmentSource: SoundscapeAssignmentSource;
+  sceneId: string | null;
+  context: SoundscapeTriggerContext;
+  musicProgramId: string | null;
+  musicProgram: SoundscapeMusicProgram | null;
+  musicRuleId: string | null;
+  ambienceLayerIds: string[];
+  ambienceLayers: SoundscapeAmbienceLayer[];
+  ambienceRuleId: string | null;
+  soundMoments: SoundscapeSoundMoment[];
+}
+
+export interface ResolveSoundscapeStateInput {
+  library: PersistentSoundscapeLibrarySnapshot;
+  sceneAssignment?: SoundscapeSceneAssignment | null;
+  worldDefaultProfileId?: string | null;
+  context?: Partial<SoundscapeTriggerContext>;
+  sceneId?: string | null;
+}

--- a/src/types/foundry.d.ts
+++ b/src/types/foundry.d.ts
@@ -24,6 +24,10 @@ export interface FoundryGame {
   users?: FoundryCollection<FoundryUser>;
   /** Collection of all actors in the world */
   actors?: FoundryCollection<FoundryDocument>;
+  /** Collection of all scenes in the world */
+  scenes?: FoundryCollection<FoundryScene>;
+  /** Collection of all playlists in the world */
+  playlists?: FoundryCollection<FoundryPlaylist>;
   /** Collection of all compendium packs */
   packs?: FoundryCollection<FoundryCompendiumCollection>;
   /** Settings manager */
@@ -152,12 +156,22 @@ export interface FoundryDocument {
   type?: string;
   system?: Record<string, unknown>;
   ownership?: Record<string, number>;
+  active?: boolean;
   sheet?: { render(opts?: { force?: boolean }): void };
+  getFlag?(scope: string, key: string): unknown;
+  setFlag?(scope: string, key: string, value: unknown): Promise<unknown>;
+  unsetFlag?(scope: string, key: string): Promise<unknown>;
   update(data: Record<string, unknown>, options?: Record<string, unknown>): Promise<FoundryDocument>;
   createEmbeddedDocuments(type: string, data: Record<string, unknown>[], options?: Record<string, unknown>): Promise<FoundryDocument[]>;
   toObject(): Record<string, unknown>;
   [key: string]: unknown;
 }
+
+export interface FoundryScene extends FoundryDocument {
+  active?: boolean;
+}
+
+export interface FoundryPlaylist extends FoundryDocument {}
 
 /* ── Socket ───────────────────────────────────────────────── */
 
@@ -256,4 +270,3 @@ export interface DocumentSheetConfigStatic {
     options?: { types?: string[] }
   ): void;
 }
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ export type {
   FoundryModule,
   FoundryCollection,
   FoundrySettings,
+  FoundryScene,
+  FoundryPlaylist,
   SettingRegistration,
   SettingMenuRegistration,
   FoundryCompendiumCollection,
@@ -51,4 +53,3 @@ export {
   hasProperty,
   isObject,
 } from "./guards";
-


### PR DESCRIPTION
## Summary
- add the Reactive Soundscapes foundation subsystem for typed persistence, normalization, accessors, resolver logic, and a thin inspection API
- register hidden world settings and scene flag helpers for soundscape library and assignment data
- extend local Foundry shims and bootstrap/API wiring needed for issue #69
- fix two preexisting Character Creator tests that were already failing on `main` so the branch returns to a fully green state

## Testing
- npm run test
- npm run build

Closes #69
