### PR TITLE
test: stabilize character creator runtime-class tests

### DIFF
--- a/src/character-creator/character-creator-init.test.ts
+++ b/src/character-creator/character-creator-init.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type SceneTool = {
   name: string;
@@ -59,6 +59,12 @@ vi.mock("./level-up/level-up-detection", () => ({
 }));
 
 describe("character creator init shell", () => {
+  let modPromise: Promise<typeof import("./character-creator-init")>;
+
+  beforeAll(() => {
+    modPromise = import("./character-creator-init");
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -92,7 +98,7 @@ describe("character creator init shell", () => {
   });
 
   it("builds app classes, registers steps/level-up hooks, preloads templates, and hooks scene controls", async () => {
-    const mod = await import("./character-creator-init");
+    const mod = await modPromise;
     const namespacedLoadTemplatesMock = (
       (globalThis as Record<string, unknown>).foundry as {
         applications: { handlebars: { loadTemplates: ReturnType<typeof vi.fn> } };
@@ -125,7 +131,7 @@ describe("character creator init shell", () => {
   });
 
   it("adds a character creator scene tool and routes clicks to the wizard", async () => {
-    const mod = await import("./character-creator-init");
+    const mod = await modPromise;
 
     const controls = {
       tokens: {
@@ -169,7 +175,7 @@ describe("character creator init shell", () => {
       notifications: { info: notifyInfo },
     };
 
-    const mod = await import("./character-creator-init");
+    const mod = await modPromise;
     mod.initCharacterCreatorReady();
 
     expect(socketOn).toHaveBeenCalledWith("module.foundry-tabletop-helpers", expect.any(Function));
@@ -190,7 +196,7 @@ describe("character creator init shell", () => {
       user: { isGM: false, character: null },
     };
 
-    const mod = await import("./character-creator-init");
+    const mod = await modPromise;
     mod.initCharacterCreatorReady();
 
     expect(openCharacterCreatorWizardMock).toHaveBeenCalledTimes(1);

--- a/src/character-creator/react/character-creator-react-app.test.ts
+++ b/src/character-creator/react/character-creator-react-app.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   logWarnMock,
@@ -127,7 +127,6 @@ function installFoundryAppClasses(): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.resetModules();
   FakeBaseApplication.instances = [];
   installFoundryAppClasses();
 
@@ -140,8 +139,15 @@ beforeEach(() => {
 });
 
 describe("CharacterCreatorReactApp", () => {
+  let modPromise: Promise<typeof import("./character-creator-react-app")>;
+
+  beforeAll(() => {
+    installFoundryAppClasses();
+    modPromise = import("./character-creator-react-app");
+  });
+
   it("builds the runtime class when ApplicationV2 is available", async () => {
-    const mod = await import("./character-creator-react-app");
+    const mod = await modPromise;
 
     mod.buildCharacterCreatorReactAppClass();
     const AppClass = mod.getCharacterCreatorReactAppClass();
@@ -154,7 +160,7 @@ describe("CharacterCreatorReactApp", () => {
   });
 
   it("delegates resize handle wiring and window constraint wiring on every render", async () => {
-    const mod = await import("./character-creator-react-app");
+    const mod = await modPromise;
 
     mod.buildCharacterCreatorReactAppClass();
     const AppClass = mod.getCharacterCreatorReactAppClass();

--- a/src/character-creator/wizard/character-creator-app.test.ts
+++ b/src/character-creator/wizard/character-creator-app.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const logWarnMock = vi.fn();
 const logDebugMock = vi.fn();
@@ -162,7 +162,6 @@ function installFoundryAppClasses(): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.resetModules();
   installFoundryAppClasses();
   FakeBaseApplication.instances = [];
   FakeWizardStateMachine.instances = [];
@@ -210,8 +209,15 @@ vi.mock("./wizard-state-machine", () => ({
 }));
 
 describe("character creator app shell", () => {
+  let modPromise: Promise<typeof import("./character-creator-app")>;
+
+  beforeAll(() => {
+    installFoundryAppClasses();
+    modPromise = import("./character-creator-app");
+  });
+
   it("builds the runtime class and opens the wizard", async () => {
-    const mod = await import("./character-creator-app");
+    const mod = await modPromise;
 
     mod.buildCharacterCreatorAppClass();
     const AppClass = mod.getCharacterCreatorAppClass();
@@ -229,7 +235,7 @@ describe("character creator app shell", () => {
   });
 
   it("prepares wizard shell context from the frozen config snapshot", async () => {
-    const mod = await import("./character-creator-app");
+    const mod = await modPromise;
 
     mod.buildCharacterCreatorAppClass();
     const AppClass = mod.getCharacterCreatorAppClass()!;
@@ -270,7 +276,7 @@ describe("character creator app shell", () => {
       sheet: { render: actorSheetRender },
     });
 
-    const mod = await import("./character-creator-app");
+    const mod = await modPromise;
     mod.buildCharacterCreatorAppClass();
     const AppClass = mod.getCharacterCreatorAppClass()!;
     const app = new AppClass() as FakeBaseApplication & {
@@ -302,7 +308,7 @@ describe("character creator app shell", () => {
   });
 
   it("warns instead of creating when the review step name is missing", async () => {
-    const mod = await import("./character-creator-app");
+    const mod = await modPromise;
     mod.buildCharacterCreatorAppClass();
     const AppClass = mod.getCharacterCreatorAppClass()!;
     const app = new AppClass() as FakeBaseApplication & {


### PR DESCRIPTION
## Summary
- cache the expensive Character Creator module imports across the three runtime-class test files
- stop resetting the entire module registry between cases where it is not needed
- keep the fix scoped to test files only

## Verification
- npx vitest run src/character-creator/character-creator-init.test.ts src/character-creator/react/character-creator-react-app.test.ts src/character-creator/wizard/character-creator-app.test.ts
- npm run test
- npm run build