### PR TITLE
feat: add soundscape studio workflow

### DIFF
--- a/src/character-creator/react/character-creator-react-app.test.ts
+++ b/src/character-creator/react/character-creator-react-app.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   logWarnMock,
@@ -139,12 +139,8 @@ beforeEach(() => {
 });
 
 describe("CharacterCreatorReactApp", () => {
-  let modPromise: Promise<typeof import("./character-creator-react-app")>;
-
-  beforeAll(() => {
-    installFoundryAppClasses();
-    modPromise = import("./character-creator-react-app");
-  });
+  installFoundryAppClasses();
+  const modPromise = import("./character-creator-react-app");
 
   it("builds the runtime class when ApplicationV2 is available", async () => {
     const mod = await modPromise;
@@ -157,7 +153,7 @@ describe("CharacterCreatorReactApp", () => {
       .toBe("Character Creation");
     expect(buildLegacyCharacterCreatorAppClassMock).toHaveBeenCalled();
     expect(logDebugMock).toHaveBeenCalledWith("Character Creator: CharacterCreatorReactApp class built");
-  });
+  }, 10000);
 
   it("delegates resize handle wiring and window constraint wiring on every render", async () => {
     const mod = await modPromise;

--- a/src/fth-api.test.ts
+++ b/src/fth-api.test.ts
@@ -15,6 +15,7 @@ const buildSoundscapeApiMock = vi.fn(() => ({
   soundscapes: {
     getLibrary: vi.fn(),
     resolve: vi.fn(),
+    openStudio: vi.fn(),
   },
 }));
 
@@ -75,6 +76,7 @@ describe("fth api", () => {
     api.levelUp("actor-1");
     api.soundscapes.getLibrary();
     api.soundscapes.resolve();
+    api.soundscapes.openStudio();
 
     expect(setLevelMock).toHaveBeenCalledWith("debug");
     expect(openAssetManagerMock).toHaveBeenCalledTimes(1);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,6 +37,7 @@ const registerCharacterCreatorHooksMock = vi.fn();
 const initCharacterCreatorReadyMock = vi.fn();
 const attachFthApiMock = vi.fn();
 const registerSoundscapeSettingsMock = vi.fn();
+const registerSoundscapeStudioHooksMock = vi.fn();
 
 vi.mock("./logger", () => ({
   MOD: "foundry-tabletop-helpers",
@@ -117,6 +118,10 @@ vi.mock("./soundscapes/soundscape-settings", () => ({
   registerSoundscapeSettings: registerSoundscapeSettingsMock,
 }));
 
+vi.mock("./soundscapes/soundscape-studio-app", () => ({
+  registerSoundscapeStudioHooks: registerSoundscapeStudioHooksMock,
+}));
+
 describe("index shell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -166,6 +171,7 @@ describe("index shell", () => {
     expect(registerAssetManagerSettingsMock).toHaveBeenCalledWith(settings);
     expect(registerCharacterCreatorSettingsMock).toHaveBeenCalledWith(settings);
     expect(registerSoundscapeSettingsMock).toHaveBeenCalledWith(settings);
+    expect(registerSoundscapeStudioHooksMock).toHaveBeenCalledTimes(1);
     expect(registerLPCSSheetMock).toHaveBeenCalledTimes(1);
     expect(preloadLPCSTemplatesMock).toHaveBeenCalledTimes(1);
     expect(registerInitiativeHooksMock).toHaveBeenCalledTimes(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,9 @@ import {
   initCharacterCreatorReady,
 } from "./character-creator/character-creator-init";
 import { registerSoundscapeSettings } from "./soundscapes/soundscape-settings";
+import {
+  registerSoundscapeStudioHooks,
+} from "./soundscapes/soundscape-studio-app";
 
 interface SceneControlTool {
   name: string;
@@ -90,6 +93,7 @@ function onInit(): void {
 
   // Reactive Soundscapes foundation settings
   if (settings) registerSoundscapeSettings(settings);
+  registerSoundscapeStudioHooks();
 
   registerAssetManagerSceneControlHook();
 

--- a/src/soundscapes/soundscape-api.ts
+++ b/src/soundscapes/soundscape-api.ts
@@ -1,9 +1,11 @@
 import type { PersistentSoundscapeLibrarySnapshot, ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
 import { getStoredSoundscapeLibrarySnapshot, resolveStoredSoundscapeState } from "./soundscape-accessors";
+import { openSoundscapeStudio } from "./soundscape-studio-app";
 
 export interface FthSoundscapeDebugApi {
   getLibrary: () => PersistentSoundscapeLibrarySnapshot | null;
   resolve: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => ResolvedSoundscapeState | null;
+  openStudio: () => void;
 }
 
 export interface FthSoundscapeApi {
@@ -15,6 +17,7 @@ export function buildSoundscapeApi(): FthSoundscapeApi {
     soundscapes: {
       getLibrary: () => getStoredSoundscapeLibrarySnapshot(),
       resolve: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => resolveStoredSoundscapeState(sceneId, context),
+      openStudio: () => openSoundscapeStudio(),
     },
   };
 }

--- a/src/soundscapes/soundscape-studio-app.test.tsx
+++ b/src/soundscapes/soundscape-studio-app.test.tsx
@@ -1,0 +1,212 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  logWarnMock,
+  logDebugMock,
+  getHooksMock,
+  loadTemplatesMock,
+  isGMMock,
+  getUIMock,
+  getFoundryReactMountMock,
+  foundryReactRenderMock,
+  foundryReactUnmountMock,
+  ensureNativeWindowResizeHandleMock,
+  ensureWindowSizeConstraintsMock,
+} = vi.hoisted(() => ({
+  logWarnMock: vi.fn(),
+  logDebugMock: vi.fn(),
+  getHooksMock: vi.fn(),
+  loadTemplatesMock: vi.fn(),
+  isGMMock: vi.fn(() => true),
+  getUIMock: vi.fn(),
+  getFoundryReactMountMock: vi.fn(),
+  foundryReactRenderMock: vi.fn(),
+  foundryReactUnmountMock: vi.fn(),
+  ensureNativeWindowResizeHandleMock: vi.fn(),
+  ensureWindowSizeConstraintsMock: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+  MOD: "foundry-tabletop-helpers",
+  Log: {
+    warn: logWarnMock,
+    debug: logDebugMock,
+  },
+}));
+
+vi.mock("../types", () => ({
+  getHooks: getHooksMock,
+  getUI: getUIMock,
+  isGM: isGMMock,
+  loadTemplates: loadTemplatesMock,
+}));
+
+vi.mock("../ui/foundry/react/foundry-react-application", () => ({
+  getFoundryReactMount: getFoundryReactMountMock,
+  FoundryReactRenderer: class {
+    render = foundryReactRenderMock;
+    unmount = foundryReactUnmountMock;
+  },
+}));
+
+vi.mock("../ui/foundry/application-v2/window-resize-handle", () => ({
+  ensureNativeWindowResizeHandle: ensureNativeWindowResizeHandleMock,
+}));
+
+vi.mock("../ui/foundry/application-v2/window-size-constraints", () => ({
+  ensureWindowSizeConstraints: ensureWindowSizeConstraintsMock,
+}));
+
+class FakeElement {
+  public dataset: Record<string, string> = {};
+  public attributes = [] as unknown as NamedNodeMap;
+  private readonly selectors = new Map<string, unknown>();
+
+  constructor(public readonly tagName = "div") {}
+
+  setQueryResult(selector: string, value: unknown): void {
+    this.selectors.set(selector, value);
+  }
+
+  querySelector(selector: string): unknown {
+    return this.selectors.get(selector) ?? null;
+  }
+
+  getAttributeNames(): string[] {
+    return Object.keys(this.dataset);
+  }
+}
+
+class FakeBaseApplication {
+  static instances: FakeBaseApplication[] = [];
+  static DEFAULT_OPTIONS = {};
+  static PARTS = {};
+
+  element: FakeElement | null = null;
+  render = vi.fn();
+  close = vi.fn(async () => {});
+
+  constructor(..._args: unknown[]) {
+    FakeBaseApplication.instances.push(this);
+  }
+
+  async _preparePartContext(_partId: string, _context: unknown, _options: unknown): Promise<Record<string, unknown>> {
+    return {};
+  }
+}
+
+function installFoundryAppClasses(): void {
+  (globalThis as Record<string, unknown>).HTMLElement = FakeElement;
+  (globalThis as Record<string, unknown>).foundry = {
+    applications: {
+      api: {
+        ApplicationV2: FakeBaseApplication,
+        HandlebarsApplicationMixin: <TBase extends new (...args: any[]) => FakeBaseApplication>(Base: TBase) =>
+          class Mixed extends Base {},
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  FakeBaseApplication.instances = [];
+  installFoundryAppClasses();
+
+  getHooksMock.mockReturnValue({ on: vi.fn() });
+  getUIMock.mockReturnValue({ notifications: { warn: vi.fn() } });
+  getFoundryReactMountMock.mockImplementation((root: FakeElement | null | undefined) => {
+    return root?.querySelector("[data-fth-react-root]") as HTMLElement | null;
+  });
+});
+
+describe("SoundscapeStudioApp", () => {
+  let modPromise: Promise<typeof import("./soundscape-studio-app")>;
+
+  beforeAll(() => {
+    installFoundryAppClasses();
+    modPromise = import("./soundscape-studio-app");
+  });
+
+  it("builds the runtime class when ApplicationV2 is available", async () => {
+    const mod = await modPromise;
+
+    mod.buildSoundscapeStudioAppClass();
+    const AppClass = mod.getSoundscapeStudioAppClass();
+
+    expect(AppClass).not.toBeNull();
+    expect((AppClass as { DEFAULT_OPTIONS?: { window?: { title?: string } } }).DEFAULT_OPTIONS?.window?.title)
+      .toBe("Soundscape Studio");
+    expect(logDebugMock).toHaveBeenCalledWith("Reactive Soundscapes: Soundscape Studio class built");
+  });
+
+  it("registers the template preload and scene control hook", async () => {
+    const mod = await modPromise;
+    const hooks = { on: vi.fn() };
+    getHooksMock.mockReturnValue(hooks);
+
+    mod.registerSoundscapeStudioHooks();
+
+    expect(loadTemplatesMock).toHaveBeenCalledWith([
+      "modules/foundry-tabletop-helpers/templates/soundscapes/soundscape-studio-root.hbs",
+    ]);
+    expect(hooks.on).toHaveBeenCalledWith("getSceneControlButtons", expect.any(Function));
+  });
+
+  it("injects a scene control button that opens the studio", async () => {
+    const mod = await modPromise;
+    mod.buildSoundscapeStudioAppClass();
+
+    const controls: {
+      tokens: {
+        tools: Record<string, {
+          name: string;
+          title: string;
+          icon: string;
+          order: number;
+          button: boolean;
+          visible: boolean;
+          onChange: () => void;
+        }>;
+      };
+    } = {
+      tokens: {
+        tools: {
+          select: {
+            name: "select",
+            title: "Select",
+            icon: "fa-solid fa-expand",
+            order: 0,
+            button: true,
+            visible: true,
+            onChange: () => undefined,
+          },
+        },
+      },
+    };
+
+    mod.__soundscapeStudioAppInternals.onGetSceneControlButtonsSoundscapeStudio(controls);
+
+    expect(controls.tokens.tools["fth-soundscape-studio"]).toMatchObject({
+      name: "fth-soundscape-studio",
+      title: "Soundscape Studio",
+      order: 1,
+      button: true,
+      visible: true,
+    });
+
+    controls.tokens.tools["fth-soundscape-studio"].onChange();
+    expect(FakeBaseApplication.instances.at(-1)?.render).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("warns non-gm users instead of opening the studio", async () => {
+    const mod = await modPromise;
+    isGMMock.mockReturnValue(false);
+    const warn = vi.fn();
+    getUIMock.mockReturnValue({ notifications: { warn } });
+
+    mod.openSoundscapeStudio();
+
+    expect(warn).toHaveBeenCalledWith("Soundscape Studio is only available to GMs.");
+  });
+});

--- a/src/soundscapes/soundscape-studio-app.tsx
+++ b/src/soundscapes/soundscape-studio-app.tsx
@@ -1,0 +1,1285 @@
+import { useEffect, useState, type JSX, type ReactNode } from "react";
+
+import { Log, MOD } from "../logger";
+import { getHooks, getUI, isGM, loadTemplates } from "../types";
+import { getFoundryReactMount, FoundryReactRenderer } from "../ui/foundry/react/foundry-react-application";
+import { ensureNativeWindowResizeHandle, type ApplicationV2Like } from "../ui/foundry/application-v2/window-resize-handle";
+import {
+  ensureWindowSizeConstraints,
+  type ApplicationPositionLike,
+  type ApplicationV2PositionLike,
+  type WindowSizeConstraints,
+} from "../ui/foundry/application-v2/window-size-constraints";
+import {
+  getSceneSoundscapeAssignment,
+  getSoundscapeLibrarySnapshot,
+  getSoundscapeSceneById,
+  getSoundscapeWorldDefaultProfileId,
+  setSceneSoundscapeAssignment,
+  setSoundscapeLibrarySnapshot,
+  setSoundscapeWorldDefaultProfileId,
+} from "./soundscape-accessors";
+import {
+  type PersistentSoundscapeLibrarySnapshot,
+  type ResolvedSoundscapeState,
+  type SoundscapeProfile,
+  type SoundscapeRule,
+  type SoundscapeSceneAssignment,
+  type SoundscapeTriggerContext,
+} from "./soundscape-types";
+import {
+  createSoundscapeAmbienceLayer,
+  createSoundscapeMusicProgram,
+  createSoundscapeProfile,
+  createSoundscapeRule,
+  createSoundscapeSoundMoment,
+  duplicateSoundscapeProfile,
+  listKnownPlaylists,
+  listSoundscapeProfiles,
+  listSoundscapeScenes,
+  parseUuidText,
+  removeProfileFromLibrary,
+  replaceProfileInLibrary,
+  resolveSoundscapeStudioPreview,
+  sanitizeSceneAssignmentsForProfileDeletion,
+  stringifyUuidText,
+  updateStudioSceneAssignmentProfile,
+  validateSoundscapeStudioData,
+  type SoundscapeStudioValidationMessage,
+} from "./soundscape-studio-helpers";
+
+interface RuntimeApplicationBase extends ApplicationV2PositionLike {
+  element?: Element | null;
+  hasFrame?: boolean;
+  window?: ApplicationV2Like["window"];
+  position?: Partial<ApplicationPositionLike> | null;
+  render(options?: Record<string, unknown>): void;
+  close(options?: unknown): Promise<void>;
+  _preparePartContext?(partId: string, context: unknown, options: unknown): Promise<unknown>;
+}
+
+interface RuntimeApplicationClass {
+  new (): RuntimeApplicationBase;
+}
+
+type RuntimeHandlebarsApplicationMixin = (base: RuntimeApplicationClass) => RuntimeApplicationClass;
+
+interface RuntimeFoundryAppClasses {
+  HandlebarsApplicationMixin?: RuntimeHandlebarsApplicationMixin;
+  ApplicationV2?: RuntimeApplicationClass;
+}
+
+interface SceneControlTool {
+  name: string;
+  title: string;
+  icon: string;
+  order: number;
+  button: boolean;
+  visible: boolean;
+  onChange: () => void;
+}
+
+interface SceneControls {
+  tokens?: {
+    tools?: Record<string, SceneControlTool>;
+  };
+}
+
+const SOUNDSCAPE_STUDIO_WINDOW_CONSTRAINTS = {
+  minWidth: 840,
+  maxWidth: 1560,
+  minHeight: 620,
+  maxHeight: 1120,
+} satisfies WindowSizeConstraints;
+
+const getFoundryAppClasses = () => {
+  const g = globalThis as Record<string, unknown>;
+  const api = (g.foundry as Record<string, unknown> | undefined)
+    ?.applications as Record<string, unknown> | undefined;
+  const appApi = api?.api as Record<string, unknown> | undefined;
+  return {
+    HandlebarsApplicationMixin: appApi?.HandlebarsApplicationMixin as RuntimeHandlebarsApplicationMixin | undefined,
+    ApplicationV2: appApi?.ApplicationV2 as RuntimeApplicationClass | undefined,
+  } satisfies RuntimeFoundryAppClasses;
+};
+
+function defaultPreviewContext(): SoundscapeTriggerContext {
+  return {
+    manualPreview: false,
+    inCombat: false,
+    weather: null,
+    timeOfDay: null,
+  };
+}
+
+function getSelectedProfile(
+  snapshot: PersistentSoundscapeLibrarySnapshot,
+  profileId: string | null,
+): SoundscapeProfile | null {
+  if (!profileId) return null;
+  return snapshot.profiles[profileId] ?? null;
+}
+
+function getNextSelectedProfileId(snapshot: PersistentSoundscapeLibrarySnapshot): string | null {
+  return listSoundscapeProfiles(snapshot)[0]?.id ?? null;
+}
+
+function renderAssignmentBadge(
+  assignment: SoundscapeSceneAssignment | null,
+  worldDefaultProfileId: string | null,
+): { label: string; tone: string } {
+  if (assignment?.profileId) {
+    return { label: "Direct", tone: "border-[#d6b06e]/45 bg-[rgba(214,176,110,0.12)] text-[#f1d8a5]" };
+  }
+  if (worldDefaultProfileId) {
+    return { label: "Inherited", tone: "border-white/12 bg-white/[0.05] text-[#d8d0c7]" };
+  }
+  return { label: "Unassigned", tone: "border-white/10 bg-white/[0.03] text-[#aba39a]" };
+}
+
+function SoundscapeStudioView(): JSX.Element {
+  const [library, setLibrary] = useState<PersistentSoundscapeLibrarySnapshot>(() => getSoundscapeLibrarySnapshot());
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(() => getNextSelectedProfileId(getSoundscapeLibrarySnapshot()));
+  const [worldDefaultProfileId, setWorldDefaultProfileIdState] = useState<string | null>(() => getSoundscapeWorldDefaultProfileId());
+  const [scenes] = useState(() => listSoundscapeScenes());
+  const [playlists] = useState(() => listKnownPlaylists());
+  const [sceneAssignments, setSceneAssignments] = useState<Record<string, SoundscapeSceneAssignment | null>>({});
+  const [previewSceneId, setPreviewSceneId] = useState<string | null>(null);
+  const [previewContext, setPreviewContext] = useState<SoundscapeTriggerContext>(defaultPreviewContext);
+  const [messages, setMessages] = useState<SoundscapeStudioValidationMessage[]>([]);
+  const [status, setStatus] = useState<string>("Ready to author soundscapes.");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const selectedProfile = getSelectedProfile(library, selectedProfileId);
+  const previewState = selectedProfile
+    ? resolveSoundscapeStudioPreview({
+      library,
+      selectedProfileId,
+      previewSceneId,
+      sceneAssignments,
+      worldDefaultProfileId,
+      context: previewContext,
+    })
+    : null;
+
+  useEffect(() => {
+    const assignments = Object.fromEntries(
+      scenes.map((scene) => [scene.id, getSceneSoundscapeAssignment(getSoundscapeSceneById(scene.id))]),
+    );
+    setSceneAssignments(assignments);
+    setPreviewSceneId(scenes.find((scene) => scene.active)?.id ?? scenes[0]?.id ?? null);
+  }, []);
+
+  function updateProfile(nextProfile: SoundscapeProfile): void {
+    setLibrary((current) => replaceProfileInLibrary(current, nextProfile));
+  }
+
+  function createProfile(): void {
+    const profile = createSoundscapeProfile(Object.keys(library.profiles));
+    setLibrary((current) => replaceProfileInLibrary(current, profile));
+    setSelectedProfileId(profile.id);
+    setStatus(`Created ${profile.name}.`);
+    setMessages([]);
+  }
+
+  function duplicateProfile(): void {
+    if (!selectedProfile) return;
+    const profile = duplicateSoundscapeProfile(selectedProfile, Object.keys(library.profiles));
+    setLibrary((current) => replaceProfileInLibrary(current, profile));
+    setSelectedProfileId(profile.id);
+    setStatus(`Duplicated ${selectedProfile.name}.`);
+    setMessages([]);
+  }
+
+  function deleteProfile(): void {
+    if (!selectedProfile) return;
+
+    const nextLibrary = removeProfileFromLibrary(library, selectedProfile.id);
+    setLibrary(nextLibrary);
+    setSceneAssignments((current) => sanitizeSceneAssignmentsForProfileDeletion(current, selectedProfile.id));
+    setWorldDefaultProfileIdState((current) => current === selectedProfile.id ? null : current);
+    setSelectedProfileId(getNextSelectedProfileId(nextLibrary));
+    setStatus(`Deleted ${selectedProfile.name}.`);
+    setMessages([]);
+  }
+
+  async function saveStudio(): Promise<void> {
+    setIsSaving(true);
+    setStatus("Saving soundscape studio changes...");
+
+    try {
+      const validation = await validateSoundscapeStudioData(library, worldDefaultProfileId, sceneAssignments, {
+        knownPlaylistUuids: playlists.map((playlist) => playlist.uuid),
+      });
+
+      setMessages(validation.messages);
+      if (!validation.isValid) {
+        setStatus("Save blocked until the studio validation issues are resolved.");
+        return;
+      }
+
+      await setSoundscapeLibrarySnapshot(library);
+      await setSoundscapeWorldDefaultProfileId(worldDefaultProfileId);
+
+      for (const scene of scenes) {
+        const sceneDoc = getSoundscapeSceneById(scene.id);
+        if (!sceneDoc) continue;
+        await setSceneSoundscapeAssignment(sceneDoc, sceneAssignments[scene.id] ?? null);
+      }
+
+      setStatus("Soundscape studio changes saved.");
+    } catch {
+      setStatus("Saving failed. Check the console or Foundry permissions and try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function updateRule(ruleId: string, updater: (rule: SoundscapeRule) => SoundscapeRule): void {
+    if (!selectedProfile) return;
+    updateProfile({
+      ...selectedProfile,
+      rules: selectedProfile.rules.map((rule) => rule.id === ruleId ? updater(rule) : rule),
+    });
+  }
+
+  return (
+    <div className="fth-react-app-shell fth-ui-root flex h-full min-h-0 flex-col overflow-hidden bg-[radial-gradient(circle_at_top,rgba(114,78,33,0.18),transparent_28%),linear-gradient(180deg,#120f12_0%,#1b171c_48%,#0e0c0f_100%)] text-[#f5efe6]">
+      <div className="border-b border-white/8 bg-[linear-gradient(180deg,rgba(20,17,19,0.92),rgba(12,10,12,0.78))] px-5 py-4 md:px-6">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="min-w-0">
+            <div className="font-fth-cc-ui text-[0.68rem] uppercase tracking-[0.28em] text-[#d9bb84]/76">Reactive Soundscapes</div>
+            <h1 className="mt-2 font-fth-cc-display text-[1.75rem] leading-none text-[#f7e7ca] md:text-[2rem]">
+              Soundscape Studio
+            </h1>
+            <p className="mt-2 max-w-4xl font-fth-cc-body text-[0.96rem] leading-6 text-[#d6cec5]">
+              Author music, atmosphere, manual moments, and trigger rules in one GM-only workspace. This studio saves authored state and scene assignments only; live playback stays in later runtime issues.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <StudioButton label="New Profile" onClick={createProfile} tone="gold" />
+            <StudioButton disabled={!selectedProfile} label="Duplicate" onClick={duplicateProfile} />
+            <StudioButton disabled={!selectedProfile} label="Delete" onClick={deleteProfile} tone="danger" />
+            <StudioButton disabled={isSaving} label={isSaving ? "Saving..." : "Save Studio"} onClick={() => void saveStudio()} tone="gold" />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden xl:flex-row">
+        <aside className="border-b border-white/8 bg-[rgba(8,8,10,0.38)] xl:w-[20rem] xl:border-b-0 xl:border-r xl:border-white/8">
+          <div className="flex items-center justify-between px-4 py-3">
+            <div>
+              <div className="font-fth-cc-ui text-[0.62rem] uppercase tracking-[0.24em] text-[#d8ba84]/72">Profiles</div>
+              <div className="mt-1 font-fth-cc-body text-sm text-[#cfc7be]">{Object.keys(library.profiles).length} authored</div>
+            </div>
+          </div>
+          <div className="max-h-[16rem] overflow-y-auto px-3 pb-4 xl:max-h-none xl:pb-6">
+            {listSoundscapeProfiles(library).length === 0 ? (
+              <EmptyPanel message="No soundscapes yet. Create a profile to start authoring music, ambience, and trigger rules." />
+            ) : (
+              <div className="space-y-2">
+                {listSoundscapeProfiles(library).map((profile) => {
+                  const isSelected = profile.id === selectedProfileId;
+                  return (
+                    <button
+                      className={[
+                        "w-full rounded-[1rem] border px-4 py-3 text-left transition",
+                        isSelected
+                          ? "border-[#ddb675]/48 bg-[linear-gradient(180deg,rgba(84,60,32,0.48),rgba(23,19,18,0.94))] shadow-[0_18px_38px_rgba(0,0,0,0.28)]"
+                          : "border-white/8 bg-white/[0.03] hover:border-[#d4b06d]/28 hover:bg-white/[0.05]",
+                      ].join(" ")}
+                      key={profile.id}
+                      onClick={() => setSelectedProfileId(profile.id)}
+                      type="button"
+                    >
+                      <div className="font-fth-cc-display text-[1.12rem] text-[#f6e7cc]">{profile.name}</div>
+                      <div className="mt-1 font-fth-cc-ui text-[0.58rem] uppercase tracking-[0.18em] text-[#c9bfaf]">{profile.id}</div>
+                      <div className="mt-3 flex flex-wrap gap-2 font-fth-cc-ui text-[0.55rem] uppercase tracking-[0.16em] text-[#d8cfbe]">
+                        <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1">{Object.keys(profile.musicPrograms).length} music</span>
+                        <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1">{Object.keys(profile.ambienceLayers).length} ambience</span>
+                        <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-1">{profile.rules.length} rules</span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto px-4 py-4 md:px-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(22rem,0.95fr)]">
+          <div className="space-y-4">
+            <StudioCard title="Profile">
+              {selectedProfile ? (
+                <div className="grid gap-4 md:grid-cols-2">
+                  <LabeledField label="Name">
+                    <input
+                      className={studioInputClassName()}
+                      onChange={(event) => updateProfile({ ...selectedProfile, name: event.target.value })}
+                      type="text"
+                      value={selectedProfile.name}
+                    />
+                  </LabeledField>
+                  <LabeledField label="Profile Id">
+                    <input className={studioInputClassName("opacity-75")} readOnly type="text" value={selectedProfile.id} />
+                  </LabeledField>
+                </div>
+              ) : (
+                <EmptyPanel message="Create a soundscape profile to unlock the music, atmosphere, and trigger editors." />
+              )}
+            </StudioCard>
+
+            <StudioCard
+              action={selectedProfile ? (
+                <StudioInlineButton
+                  label="Add Program"
+                  onClick={() => {
+                    if (!selectedProfile) return;
+                    const musicProgram = createSoundscapeMusicProgram(Object.keys(selectedProfile.musicPrograms));
+                    updateProfile({
+                      ...selectedProfile,
+                      musicPrograms: {
+                        ...selectedProfile.musicPrograms,
+                        [musicProgram.id]: musicProgram,
+                      },
+                    });
+                  }}
+                />
+              ) : null}
+              title="Music"
+            >
+              {selectedProfile && Object.keys(selectedProfile.musicPrograms).length > 0 ? (
+                <div className="space-y-4">
+                  {Object.values(selectedProfile.musicPrograms).map((program) => (
+                    <EntityCard
+                      key={program.id}
+                      onRemove={() => {
+                        const nextPrograms = { ...selectedProfile.musicPrograms };
+                        delete nextPrograms[program.id];
+                        updateProfile({ ...selectedProfile, musicPrograms: nextPrograms });
+                      }}
+                      title={program.name}
+                    >
+                      <div className="grid gap-4 md:grid-cols-3">
+                        <LabeledField label="Name">
+                          <input
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              musicPrograms: {
+                                ...selectedProfile.musicPrograms,
+                                [program.id]: { ...program, name: event.target.value },
+                              },
+                            })}
+                            type="text"
+                            value={program.name}
+                          />
+                        </LabeledField>
+                        <LabeledField label="Selection">
+                          <select
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              musicPrograms: {
+                                ...selectedProfile.musicPrograms,
+                                [program.id]: {
+                                  ...program,
+                                  selectionMode: event.target.value === "random" ? "random" : "sequential",
+                                },
+                              },
+                            })}
+                            value={program.selectionMode}
+                          >
+                            <option value="sequential">Sequential</option>
+                            <option value="random">Random</option>
+                          </select>
+                        </LabeledField>
+                        <LabeledField label="Delay After Track (seconds)">
+                          <input
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              musicPrograms: {
+                                ...selectedProfile.musicPrograms,
+                                [program.id]: { ...program, delaySeconds: Number(event.target.value) || 0 },
+                              },
+                            })}
+                            type="number"
+                            value={program.delaySeconds}
+                          />
+                        </LabeledField>
+                      </div>
+                      <LabeledField label="Playlist UUIDs">
+                        <textarea
+                          className={studioTextAreaClassName()}
+                          onChange={(event) => updateProfile({
+                            ...selectedProfile,
+                            musicPrograms: {
+                              ...selectedProfile.musicPrograms,
+                              [program.id]: { ...program, playlistUuids: parseUuidText(event.target.value) },
+                            },
+                          })}
+                          rows={4}
+                          value={stringifyUuidText(program.playlistUuids)}
+                        />
+                      </LabeledField>
+                    </EntityCard>
+                  ))}
+                </div>
+              ) : (
+                <EmptyPanel message="Music programs decide how playlists are selected and how long the score rests between tracks." />
+              )}
+
+              {playlists.length > 0 ? (
+                <div className="mt-4 rounded-[1rem] border border-white/8 bg-black/20 p-3">
+                  <div className="font-fth-cc-ui text-[0.58rem] uppercase tracking-[0.18em] text-[#d7bc8c]/72">Known Playlists</div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-2">
+                    {playlists.map((playlist) => (
+                      <div className="rounded-[0.85rem] border border-white/8 bg-white/[0.03] px-3 py-2" key={playlist.id}>
+                        <div className="font-fth-cc-body text-sm text-[#f2eadf]">{playlist.name}</div>
+                        <div className="mt-1 break-all font-fth-cc-ui text-[0.56rem] uppercase tracking-[0.14em] text-[#bbb1a7]">
+                          {playlist.uuid}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </StudioCard>
+
+            <StudioCard
+              action={selectedProfile ? (
+                <StudioInlineButton
+                  label="Add Layer"
+                  onClick={() => {
+                    if (!selectedProfile) return;
+                    const ambienceLayer = createSoundscapeAmbienceLayer(Object.keys(selectedProfile.ambienceLayers));
+                    updateProfile({
+                      ...selectedProfile,
+                      ambienceLayers: {
+                        ...selectedProfile.ambienceLayers,
+                        [ambienceLayer.id]: ambienceLayer,
+                      },
+                    });
+                  }}
+                />
+              ) : null}
+              title="Atmosphere"
+            >
+              {selectedProfile && Object.keys(selectedProfile.ambienceLayers).length > 0 ? (
+                <div className="space-y-4">
+                  {Object.values(selectedProfile.ambienceLayers).map((layer) => (
+                    <EntityCard
+                      key={layer.id}
+                      onRemove={() => {
+                        const nextLayers = { ...selectedProfile.ambienceLayers };
+                        delete nextLayers[layer.id];
+                        updateProfile({ ...selectedProfile, ambienceLayers: nextLayers });
+                      }}
+                      title={layer.name}
+                    >
+                      <div className="grid gap-4 md:grid-cols-4">
+                        <LabeledField label="Name">
+                          <input
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              ambienceLayers: {
+                                ...selectedProfile.ambienceLayers,
+                                [layer.id]: { ...layer, name: event.target.value },
+                              },
+                            })}
+                            type="text"
+                            value={layer.name}
+                          />
+                        </LabeledField>
+                        <LabeledField label="Mode">
+                          <select
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              ambienceLayers: {
+                                ...selectedProfile.ambienceLayers,
+                                [layer.id]: { ...layer, mode: event.target.value === "random" ? "random" : "loop" },
+                              },
+                            })}
+                            value={layer.mode}
+                          >
+                            <option value="loop">Loop</option>
+                            <option value="random">Random</option>
+                          </select>
+                        </LabeledField>
+                        <LabeledField label="Min Delay">
+                          <input
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              ambienceLayers: {
+                                ...selectedProfile.ambienceLayers,
+                                [layer.id]: { ...layer, minDelaySeconds: Number(event.target.value) || 0 },
+                              },
+                            })}
+                            type="number"
+                            value={layer.minDelaySeconds}
+                          />
+                        </LabeledField>
+                        <LabeledField label="Max Delay">
+                          <input
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              ambienceLayers: {
+                                ...selectedProfile.ambienceLayers,
+                                [layer.id]: { ...layer, maxDelaySeconds: Number(event.target.value) || 0 },
+                              },
+                            })}
+                            type="number"
+                            value={layer.maxDelaySeconds}
+                          />
+                        </LabeledField>
+                      </div>
+                      <LabeledField label="Sound UUIDs">
+                        <textarea
+                          className={studioTextAreaClassName()}
+                          onChange={(event) => updateProfile({
+                            ...selectedProfile,
+                            ambienceLayers: {
+                              ...selectedProfile.ambienceLayers,
+                              [layer.id]: { ...layer, soundUuids: parseUuidText(event.target.value) },
+                            },
+                          })}
+                          rows={4}
+                          value={stringifyUuidText(layer.soundUuids)}
+                        />
+                      </LabeledField>
+                    </EntityCard>
+                  ))}
+                </div>
+              ) : (
+                <EmptyPanel message="Atmosphere layers cover looping beds and randomized environmental sounds." />
+              )}
+            </StudioCard>
+
+            <StudioCard
+              action={selectedProfile ? (
+                <StudioInlineButton
+                  label="Add Moment"
+                  onClick={() => {
+                    if (!selectedProfile) return;
+                    const soundMoment = createSoundscapeSoundMoment(Object.keys(selectedProfile.soundMoments));
+                    updateProfile({
+                      ...selectedProfile,
+                      soundMoments: {
+                        ...selectedProfile.soundMoments,
+                        [soundMoment.id]: soundMoment,
+                      },
+                    });
+                  }}
+                />
+              ) : null}
+              title="Moments"
+            >
+              {selectedProfile && Object.keys(selectedProfile.soundMoments).length > 0 ? (
+                <div className="space-y-4">
+                  {Object.values(selectedProfile.soundMoments).map((moment) => (
+                    <EntityCard
+                      key={moment.id}
+                      onRemove={() => {
+                        const nextMoments = { ...selectedProfile.soundMoments };
+                        delete nextMoments[moment.id];
+                        updateProfile({ ...selectedProfile, soundMoments: nextMoments });
+                      }}
+                      title={moment.name}
+                    >
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <LabeledField label="Name">
+                          <input
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              soundMoments: {
+                                ...selectedProfile.soundMoments,
+                                [moment.id]: { ...moment, name: event.target.value },
+                              },
+                            })}
+                            type="text"
+                            value={moment.name}
+                          />
+                        </LabeledField>
+                        <LabeledField label="Selection">
+                          <select
+                            className={studioInputClassName()}
+                            onChange={(event) => updateProfile({
+                              ...selectedProfile,
+                              soundMoments: {
+                                ...selectedProfile.soundMoments,
+                                [moment.id]: { ...moment, selectionMode: event.target.value === "random" ? "random" : "single" },
+                              },
+                            })}
+                            value={moment.selectionMode}
+                          >
+                            <option value="single">Single</option>
+                            <option value="random">Random</option>
+                          </select>
+                        </LabeledField>
+                      </div>
+                      <LabeledField label="Sound UUIDs">
+                        <textarea
+                          className={studioTextAreaClassName()}
+                          onChange={(event) => updateProfile({
+                            ...selectedProfile,
+                            soundMoments: {
+                              ...selectedProfile.soundMoments,
+                              [moment.id]: { ...moment, soundUuids: parseUuidText(event.target.value) },
+                            },
+                          })}
+                          rows={4}
+                          value={stringifyUuidText(moment.soundUuids)}
+                        />
+                      </LabeledField>
+                    </EntityCard>
+                  ))}
+                </div>
+              ) : (
+                <EmptyPanel message="Moments are manual cues the GM can trigger later without changing the authored soundscape state." />
+              )}
+            </StudioCard>
+
+            <StudioCard
+              action={selectedProfile ? (
+                <StudioInlineButton
+                  label="Add Rule"
+                  onClick={() => {
+                    if (!selectedProfile) return;
+                    updateProfile({
+                      ...selectedProfile,
+                      rules: [...selectedProfile.rules, createSoundscapeRule(selectedProfile.rules.map((rule) => rule.id))],
+                    });
+                  }}
+                />
+              ) : null}
+              title="Triggers"
+            >
+              {selectedProfile ? (
+                <div className="space-y-4">
+                  {selectedProfile.rules.map((rule, index) => {
+                    const triggerType = rule.trigger.type;
+                    const musicMode = !Object.prototype.hasOwnProperty.call(rule, "musicProgramId")
+                      ? "inherit"
+                      : rule.musicProgramId === null
+                        ? "clear"
+                        : "set";
+                    const ambienceMode = !Object.prototype.hasOwnProperty.call(rule, "ambienceLayerIds")
+                      ? "inherit"
+                      : rule.ambienceLayerIds === null
+                        ? "clear"
+                        : "set";
+
+                    return (
+                      <EntityCard
+                        key={rule.id}
+                        onRemove={triggerType === "base"
+                          ? undefined
+                          : () => updateProfile({
+                            ...selectedProfile,
+                            rules: selectedProfile.rules.filter((entry) => entry.id !== rule.id),
+                          })}
+                        title={triggerType === "base" ? "Base Rule" : `Rule ${index + 1}`}
+                      >
+                        <div className="grid gap-4 md:grid-cols-2">
+                          <LabeledField label="Trigger">
+                            <select
+                              className={studioInputClassName()}
+                              disabled={triggerType === "base"}
+                              onChange={(event) => {
+                                const nextType = event.target.value;
+                                updateRule(rule.id, (current) => ({
+                                  ...current,
+                                  trigger: nextType === "combat"
+                                    ? { type: "combat" }
+                                    : nextType === "weather"
+                                      ? { type: "weather", weatherKeys: [] }
+                                      : nextType === "timeOfDay"
+                                        ? { type: "timeOfDay", timeOfDay: "day" }
+                                        : nextType === "manualPreview"
+                                          ? { type: "manualPreview" }
+                                          : { type: "base" },
+                                }));
+                              }}
+                              value={triggerType}
+                            >
+                              <option value="base">Base</option>
+                              <option value="manualPreview">Manual Preview</option>
+                              <option value="combat">Combat</option>
+                              <option value="weather">Weather</option>
+                              <option value="timeOfDay">Time of Day</option>
+                            </select>
+                          </LabeledField>
+                          {triggerType === "weather" ? (
+                            <LabeledField label="Weather Keys">
+                              <input
+                                className={studioInputClassName()}
+                                onChange={(event) => updateRule(rule.id, (current) => ({
+                                  ...current,
+                                  trigger: {
+                                    type: "weather",
+                                    weatherKeys: event.target.value
+                                      .split(",")
+                                      .map((entry) => entry.trim())
+                                      .filter((entry) => entry.length > 0),
+                                  },
+                                }))}
+                                type="text"
+                                value={rule.trigger.weatherKeys.join(", ")}
+                              />
+                            </LabeledField>
+                          ) : triggerType === "timeOfDay" ? (
+                            <LabeledField label="Time of Day">
+                              <select
+                                className={studioInputClassName()}
+                                onChange={(event) => updateRule(rule.id, (current) => ({
+                                  ...current,
+                                  trigger: {
+                                    type: "timeOfDay",
+                                    timeOfDay: event.target.value === "night" ? "night" : "day",
+                                  },
+                                }))}
+                                value={rule.trigger.type === "timeOfDay" ? rule.trigger.timeOfDay : "day"}
+                              >
+                                <option value="day">Day</option>
+                                <option value="night">Night</option>
+                              </select>
+                            </LabeledField>
+                          ) : <div />}
+                        </div>
+
+                        <div className="mt-4 grid gap-4 md:grid-cols-2">
+                          <LabeledField label="Music Override">
+                            <div className="space-y-2">
+                              <select
+                                className={studioInputClassName()}
+                                onChange={(event) => updateRule(rule.id, (current) => {
+                                  const next = event.target.value;
+                                  if (next === "inherit") {
+                                    const { musicProgramId, ...rest } = current;
+                                    return rest;
+                                  }
+                                  if (next === "clear") return { ...current, musicProgramId: null };
+                                  return {
+                                    ...current,
+                                    musicProgramId: Object.keys(selectedProfile.musicPrograms)[0] ?? null,
+                                  };
+                                })}
+                                value={musicMode}
+                              >
+                                <option value="inherit">Inherit</option>
+                                <option value="clear">Clear Music</option>
+                                <option value="set">Use Program</option>
+                              </select>
+                              {musicMode === "set" ? (
+                                <select
+                                  className={studioInputClassName()}
+                                  onChange={(event) => updateRule(rule.id, (current) => ({
+                                    ...current,
+                                    musicProgramId: event.target.value || null,
+                                  }))}
+                                  value={rule.musicProgramId ?? ""}
+                                >
+                                  <option value="">Select music program</option>
+                                  {Object.values(selectedProfile.musicPrograms).map((program) => (
+                                    <option key={program.id} value={program.id}>{program.name}</option>
+                                  ))}
+                                </select>
+                              ) : null}
+                            </div>
+                          </LabeledField>
+
+                          <LabeledField label="Ambience Override">
+                            <div className="space-y-2">
+                              <select
+                                className={studioInputClassName()}
+                                onChange={(event) => updateRule(rule.id, (current) => {
+                                  const next = event.target.value;
+                                  if (next === "inherit") {
+                                    const { ambienceLayerIds, ...rest } = current;
+                                    return rest;
+                                  }
+                                  if (next === "clear") return { ...current, ambienceLayerIds: null };
+                                  return {
+                                    ...current,
+                                    ambienceLayerIds: current.ambienceLayerIds ?? [],
+                                  };
+                                })}
+                                value={ambienceMode}
+                              >
+                                <option value="inherit">Inherit</option>
+                                <option value="clear">Clear Ambience</option>
+                                <option value="set">Use Layers</option>
+                              </select>
+                              {ambienceMode === "set" ? (
+                                <div className="grid gap-2 rounded-[0.85rem] border border-white/8 bg-black/15 p-3">
+                                  {Object.values(selectedProfile.ambienceLayers).map((layer) => {
+                                    const checked = (rule.ambienceLayerIds ?? []).includes(layer.id);
+                                    return (
+                                      <label className="flex items-center gap-2 text-sm text-[#eee3d3]" key={layer.id}>
+                                        <input
+                                          checked={checked}
+                                          onChange={(event) => updateRule(rule.id, (current) => {
+                                            const currentIds = current.ambienceLayerIds ?? [];
+                                            const nextIds = event.target.checked
+                                              ? [...new Set([...currentIds, layer.id])]
+                                              : currentIds.filter((entry) => entry !== layer.id);
+                                            return { ...current, ambienceLayerIds: nextIds };
+                                          })}
+                                          type="checkbox"
+                                        />
+                                        <span>{layer.name}</span>
+                                      </label>
+                                    );
+                                  })}
+                                </div>
+                              ) : null}
+                            </div>
+                          </LabeledField>
+                        </div>
+                      </EntityCard>
+                    );
+                  })}
+                </div>
+              ) : (
+                <EmptyPanel message="Trigger rules tell the soundscape how to react when combat, weather, or time-of-day conditions change." />
+              )}
+            </StudioCard>
+          </div>
+
+          <div className="space-y-4">
+            <StudioCard title="Assignments">
+              <LabeledField label="World Default">
+                <select
+                  className={studioInputClassName()}
+                  onChange={(event) => setWorldDefaultProfileIdState(event.target.value || null)}
+                  value={worldDefaultProfileId ?? ""}
+                >
+                  <option value="">No world default</option>
+                  {listSoundscapeProfiles(library).map((profile) => (
+                    <option key={profile.id} value={profile.id}>{profile.name}</option>
+                  ))}
+                </select>
+              </LabeledField>
+
+              <div className="mt-4 space-y-3">
+                {scenes.length > 0 ? scenes.map((scene) => {
+                  const assignment = sceneAssignments[scene.id] ?? null;
+                  const badge = renderAssignmentBadge(assignment, worldDefaultProfileId);
+                  return (
+                    <div className="rounded-[1rem] border border-white/8 bg-white/[0.03] p-3" key={scene.id}>
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="font-fth-cc-body text-sm font-semibold text-[#f3ebdf]">{scene.name}</div>
+                          <div className="mt-1 font-fth-cc-ui text-[0.56rem] uppercase tracking-[0.18em] text-[#bfb7ad]">
+                            {scene.active ? "Active Scene" : "Scene"}
+                          </div>
+                        </div>
+                        <span className={`rounded-full border px-2.5 py-1 font-fth-cc-ui text-[0.56rem] uppercase tracking-[0.16em] ${badge.tone}`}>
+                          {badge.label}
+                        </span>
+                      </div>
+                      <div className="mt-3">
+                        <select
+                          className={studioInputClassName()}
+                          onChange={(event) => setSceneAssignments((current) => ({
+                            ...current,
+                            [scene.id]: updateStudioSceneAssignmentProfile(current[scene.id], event.target.value || null),
+                          }))}
+                          value={assignment?.profileId ?? ""}
+                        >
+                          <option value="">Inherit world default</option>
+                          {listSoundscapeProfiles(library).map((profile) => (
+                            <option key={profile.id} value={profile.id}>{profile.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+                  );
+                }) : (
+                  <EmptyPanel message="No scenes are available in this world yet." />
+                )}
+              </div>
+            </StudioCard>
+
+            <StudioCard title="Preview">
+              <div className="grid gap-4">
+                <LabeledField label="Scene Context">
+                  <select
+                    className={studioInputClassName()}
+                    onChange={(event) => setPreviewSceneId(event.target.value || null)}
+                    value={previewSceneId ?? ""}
+                  >
+                    <option value="">No scene selected</option>
+                    {scenes.map((scene) => (
+                      <option key={scene.id} value={scene.id}>{scene.name}</option>
+                    ))}
+                  </select>
+                </LabeledField>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <ToggleField
+                    checked={previewContext.manualPreview}
+                    label="Manual Preview"
+                    onChange={(checked) => setPreviewContext((current) => ({ ...current, manualPreview: checked }))}
+                  />
+                  <ToggleField
+                    checked={previewContext.inCombat}
+                    label="Combat"
+                    onChange={(checked) => setPreviewContext((current) => ({ ...current, inCombat: checked }))}
+                  />
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <LabeledField label="Time of Day">
+                    <select
+                      className={studioInputClassName()}
+                      onChange={(event) => setPreviewContext((current) => ({
+                        ...current,
+                        timeOfDay: event.target.value === "night"
+                          ? "night"
+                          : event.target.value === "day"
+                            ? "day"
+                            : null,
+                      }))}
+                      value={previewContext.timeOfDay ?? ""}
+                    >
+                      <option value="">None</option>
+                      <option value="day">Day</option>
+                      <option value="night">Night</option>
+                    </select>
+                  </LabeledField>
+                  <LabeledField label="Weather">
+                    <input
+                      className={studioInputClassName()}
+                      onChange={(event) => setPreviewContext((current) => ({
+                        ...current,
+                        weather: event.target.value.trim() || null,
+                      }))}
+                      placeholder="storm, rain, fog..."
+                      type="text"
+                      value={previewContext.weather ?? ""}
+                    />
+                  </LabeledField>
+                </div>
+
+                <ResolvedStatePanel state={previewState} />
+              </div>
+            </StudioCard>
+
+            <StudioCard title="Validation">
+              <div className="rounded-[1rem] border border-white/8 bg-white/[0.03] p-3">
+                <div className="font-fth-cc-body text-sm text-[#f4ebde]">{status}</div>
+                {messages.length > 0 ? (
+                  <ul className="mt-3 space-y-2">
+                    {messages.map((message, index) => (
+                      <li className="rounded-[0.9rem] border border-[#ca8e73]/35 bg-[rgba(116,45,31,0.2)] px-3 py-2 font-fth-cc-body text-sm text-[#f0d2c1]" key={`${message.path}-${index}`}>
+                        <div className="font-fth-cc-ui text-[0.54rem] uppercase tracking-[0.16em] text-[#efc2a7]/78">{message.path}</div>
+                        <div className="mt-1">{message.message}</div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="mt-3 rounded-[0.9rem] border border-[#90a677]/24 bg-[rgba(72,92,44,0.18)] px-3 py-2 font-fth-cc-body text-sm text-[#d8e7c8]">
+                    No validation issues yet.
+                  </div>
+                )}
+              </div>
+            </StudioCard>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ResolvedStatePanel({ state }: { state: ResolvedSoundscapeState | null }): JSX.Element {
+  if (!state) {
+    return <EmptyPanel message="Select or create a profile to inspect how the current trigger context resolves." />;
+  }
+
+  return (
+    <div className="rounded-[1rem] border border-white/8 bg-white/[0.03] p-3">
+      <div className="grid gap-3 md:grid-cols-2">
+        <PreviewValue label="Music">{state.musicProgram?.name ?? "No music"}</PreviewValue>
+        <PreviewValue label="Ambience">{state.ambienceLayers.length > 0 ? state.ambienceLayers.map((layer) => layer.name).join(", ") : "No ambience"}</PreviewValue>
+      </div>
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        <PreviewValue label="Assignment Source">{state.assignmentSource}</PreviewValue>
+        <PreviewValue label="Moments">{state.soundMoments.length > 0 ? state.soundMoments.map((moment) => moment.name).join(", ") : "No moments"}</PreviewValue>
+      </div>
+    </div>
+  );
+}
+
+function PreviewValue({ label, children }: { label: string; children: string }): JSX.Element {
+  return (
+    <div className="rounded-[0.9rem] border border-white/8 bg-black/15 px-3 py-2">
+      <div className="font-fth-cc-ui text-[0.54rem] uppercase tracking-[0.16em] text-[#d6ba88]/74">{label}</div>
+      <div className="mt-1 font-fth-cc-body text-sm text-[#f2eadf]">{children}</div>
+    </div>
+  );
+}
+
+function StudioCard({
+  title,
+  children,
+  action,
+}: {
+  title: string;
+  children: ReactNode;
+  action?: ReactNode;
+}): JSX.Element {
+  return (
+    <section className="rounded-[1.2rem] border border-white/8 bg-[linear-gradient(180deg,rgba(31,27,31,0.92),rgba(13,11,13,0.88))] p-4 shadow-[0_24px_60px_rgba(0,0,0,0.24)]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="font-fth-cc-display text-[1.24rem] text-[#f7e6c8]">{title}</div>
+        {action}
+      </div>
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+function EntityCard({
+  title,
+  children,
+  onRemove,
+}: {
+  title: string;
+  children: ReactNode;
+  onRemove?: () => void;
+}): JSX.Element {
+  return (
+    <div className="rounded-[1rem] border border-white/8 bg-white/[0.03] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="font-fth-cc-body text-[1rem] font-semibold text-[#f3eadf]">{title}</div>
+        {onRemove ? <StudioInlineButton label="Remove" onClick={onRemove} tone="danger" /> : null}
+      </div>
+      <div className="mt-4 space-y-4">{children}</div>
+    </div>
+  );
+}
+
+function EmptyPanel({ message }: { message: string }): JSX.Element {
+  return (
+    <div className="rounded-[1rem] border border-dashed border-white/10 bg-white/[0.02] px-4 py-5 font-fth-cc-body text-sm leading-6 text-[#c9c1b8]">
+      {message}
+    </div>
+  );
+}
+
+function LabeledField({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <label className="grid gap-2">
+      <span className="font-fth-cc-ui text-[0.58rem] uppercase tracking-[0.18em] text-[#cfb583]/74">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function ToggleField({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}): JSX.Element {
+  return (
+    <label className="flex items-center justify-between rounded-[0.95rem] border border-white/8 bg-white/[0.03] px-3 py-2">
+      <span className="font-fth-cc-body text-sm text-[#efe5d8]">{label}</span>
+      <input checked={checked} onChange={(event) => onChange(event.target.checked)} type="checkbox" />
+    </label>
+  );
+}
+
+function StudioButton({
+  label,
+  onClick,
+  disabled,
+  tone = "default",
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  tone?: "default" | "gold" | "danger";
+}): JSX.Element {
+  return (
+    <button
+      className={studioButtonClassName(tone, !!disabled)}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function StudioInlineButton({
+  label,
+  onClick,
+  tone = "default",
+}: {
+  label: string;
+  onClick: () => void;
+  tone?: "default" | "danger";
+}): JSX.Element {
+  return (
+    <button
+      className={studioButtonClassName(tone, false, "px-3 py-1.5 text-[0.58rem]")}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+function studioInputClassName(extra = ""): string {
+  return [
+    "w-full rounded-[0.9rem] border border-white/10 bg-[rgba(255,255,255,0.04)] px-3 py-2 font-fth-cc-body text-sm text-[#f4ece1] outline-none transition placeholder:text-[#8e867d]",
+    "focus:border-[#d7b776]/45 focus:bg-[rgba(255,255,255,0.06)]",
+    extra,
+  ].filter(Boolean).join(" ");
+}
+
+function studioTextAreaClassName(): string {
+  return `${studioInputClassName()} min-h-[7rem] resize-y`;
+}
+
+function studioButtonClassName(
+  tone: "default" | "gold" | "danger",
+  disabled: boolean,
+  sizeClass = "px-4 py-2",
+): string {
+  return [
+    "inline-flex items-center justify-center rounded-full border font-fth-cc-ui uppercase tracking-[0.16em] transition",
+    sizeClass,
+    disabled
+      ? "cursor-not-allowed border-white/8 bg-white/[0.04] text-[#8f877d]"
+      : tone === "gold"
+        ? "border-[#ddb675]/55 bg-[linear-gradient(180deg,rgba(101,74,37,0.96),rgba(53,37,21,0.96))] text-[#f7e2b5] hover:border-[#e6c487] hover:text-[#fff0d1]"
+        : tone === "danger"
+          ? "border-[#b26b5b]/45 bg-[rgba(93,42,34,0.42)] text-[#f2c6b8] hover:border-[#cc8a79]"
+          : "border-white/10 bg-white/[0.05] text-[#e8dfd3] hover:border-[#d3b06b]/28 hover:text-[#f8ecd4]",
+  ].join(" ");
+}
+
+let _SoundscapeStudioAppClass: RuntimeApplicationClass | null = null;
+
+export function buildSoundscapeStudioAppClass(): void {
+  const { HandlebarsApplicationMixin, ApplicationV2 } = getFoundryAppClasses();
+  if (typeof HandlebarsApplicationMixin !== "function" || typeof ApplicationV2 !== "function") {
+    Log.warn("Reactive Soundscapes: ApplicationV2 not available — Soundscape Studio disabled");
+    return;
+  }
+
+  const Base = HandlebarsApplicationMixin(ApplicationV2);
+
+  class SoundscapeStudioApp extends Base {
+    static DEFAULT_OPTIONS = {
+      id: "fth-soundscape-studio",
+      classes: ["fth-soundscape-studio", "fth-ui-root"],
+      tag: "div",
+      window: {
+        resizable: true,
+        icon: "fa-solid fa-waveform-lines",
+        title: "Soundscape Studio",
+      },
+      position: { width: 1180, height: 820 },
+    };
+
+    static PARTS = {
+      root: {
+        template: `modules/${MOD}/templates/soundscapes/soundscape-studio-root.hbs`,
+      },
+    };
+
+    private _reactRenderer = new FoundryReactRenderer();
+
+    async _prepareContext(_options: unknown): Promise<Record<string, never>> {
+      return {};
+    }
+
+    async _preparePartContext(partId: string, context: Record<string, never>, options: unknown): Promise<unknown> {
+      const base = await super._preparePartContext?.(partId, context, options) ?? {};
+      return { ...base, ...context };
+    }
+
+    async _onRender(_context: Record<string, never>, _options: unknown): Promise<void> {
+      const mount = getFoundryReactMount(this.element);
+      ensureNativeWindowResizeHandle(this);
+      ensureWindowSizeConstraints(this, SOUNDSCAPE_STUDIO_WINDOW_CONSTRAINTS);
+      if (!mount) return;
+
+      this._reactRenderer.render(mount, <SoundscapeStudioView />);
+    }
+
+    async close(options?: unknown): Promise<void> {
+      this._reactRenderer.unmount();
+      return super.close(options);
+    }
+  }
+
+  _SoundscapeStudioAppClass = SoundscapeStudioApp;
+  Log.debug("Reactive Soundscapes: Soundscape Studio class built");
+}
+
+export function getSoundscapeStudioAppClass(): RuntimeApplicationClass | null {
+  return _SoundscapeStudioAppClass;
+}
+
+export function openSoundscapeStudio(): void {
+  if (!isGM()) {
+    getUI()?.notifications?.warn?.("Soundscape Studio is only available to GMs.");
+    return;
+  }
+
+  const AppClass = getSoundscapeStudioAppClass();
+  if (!AppClass) {
+    buildSoundscapeStudioAppClass();
+  }
+
+  const RuntimeClass = getSoundscapeStudioAppClass();
+  if (!RuntimeClass) return;
+
+  const app = new RuntimeClass();
+  app.render({ force: true });
+}
+
+export function registerSoundscapeStudioHooks(): void {
+  buildSoundscapeStudioAppClass();
+  loadTemplates([`modules/${MOD}/templates/soundscapes/soundscape-studio-root.hbs`]);
+  getHooks()?.on?.("getSceneControlButtons", onGetSceneControlButtonsSoundscapeStudio);
+}
+
+function onGetSceneControlButtonsSoundscapeStudio(controls: SceneControls): void {
+  if (!isGM()) return;
+  if (!controls.tokens?.tools) return;
+
+  controls.tokens.tools["fth-soundscape-studio"] = {
+    name: "fth-soundscape-studio",
+    title: "Soundscape Studio",
+    icon: "fa-solid fa-waveform-lines",
+    order: Object.keys(controls.tokens.tools).length,
+    button: true,
+    visible: true,
+    onChange: () => openSoundscapeStudio(),
+  };
+}
+
+export const __soundscapeStudioAppInternals = {
+  onGetSceneControlButtonsSoundscapeStudio,
+};

--- a/src/soundscapes/soundscape-studio-helpers.test.ts
+++ b/src/soundscapes/soundscape-studio-helpers.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PersistentSoundscapeLibrarySnapshot, SoundscapeSceneAssignment } from "./soundscape-types";
+import {
+  createSoundscapeAmbienceLayer,
+  createSoundscapeMusicProgram,
+  createSoundscapeProfile,
+  createSoundscapeRule,
+  createSoundscapeSoundMoment,
+  duplicateSoundscapeProfile,
+  removeProfileFromLibrary,
+  replaceProfileInLibrary,
+  resolveSoundscapeStudioPreview,
+  sanitizeSceneAssignmentsForProfileDeletion,
+  updateStudioSceneAssignmentProfile,
+  validateSoundscapeStudioData,
+} from "./soundscape-studio-helpers";
+
+const { fromUuidMock } = vi.hoisted(() => ({
+  fromUuidMock: vi.fn(),
+}));
+
+vi.mock("../types", () => ({
+  fromUuid: fromUuidMock,
+  getGame: vi.fn(() => ({
+    playlists: [
+      { id: "playlist-1", name: "Town Themes", uuid: "Playlist.playlist-1" },
+    ],
+  })),
+}));
+
+function makeSnapshot(): PersistentSoundscapeLibrarySnapshot {
+  return {
+    formatVersion: 1,
+    savedAt: "2026-03-27T00:00:00.000Z",
+    profiles: {},
+  };
+}
+
+describe("soundscape studio helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromUuidMock.mockResolvedValue({ id: "doc-1" });
+  });
+
+  it("creates and duplicates profiles with base rules and unique ids", () => {
+    const profile = createSoundscapeProfile([]);
+    expect(profile.id).toBe("new-soundscape");
+    expect(profile.rules).toEqual([{ id: "base", trigger: { type: "base" } }]);
+
+    const duplicate = duplicateSoundscapeProfile(profile, [profile.id]);
+    expect(duplicate.id).toBe("new-soundscape-copy");
+    expect(duplicate.name).toBe("New Soundscape Copy");
+    expect(duplicate.rules).toEqual(profile.rules);
+  });
+
+  it("creates child entities with stable ids", () => {
+    expect(createSoundscapeMusicProgram([]).id).toBe("new-music-program");
+    expect(createSoundscapeAmbienceLayer([]).id).toBe("new-ambience-layer");
+    expect(createSoundscapeSoundMoment([]).id).toBe("new-sound-moment");
+    expect(createSoundscapeRule([]).id).toBe("soundscape-rule");
+  });
+
+  it("replaces and removes profiles in library snapshots", () => {
+    const profile = createSoundscapeProfile([]);
+    const snapshot = replaceProfileInLibrary(makeSnapshot(), profile);
+
+    expect(snapshot.profiles[profile.id]).toEqual(profile);
+
+    const removed = removeProfileFromLibrary(snapshot, profile.id);
+    expect(removed.profiles).toEqual({});
+  });
+
+  it("clears scene assignments that pointed at a deleted profile", () => {
+    const assignments: Record<string, SoundscapeSceneAssignment | null> = {
+      sceneA: { profileId: "alpha" },
+      sceneB: { profileId: "beta" },
+      sceneC: null,
+    };
+
+    expect(sanitizeSceneAssignmentsForProfileDeletion(assignments, "alpha")).toEqual({
+      sceneA: null,
+      sceneB: { profileId: "beta" },
+      sceneC: null,
+    });
+  });
+
+  it("preserves scene overrides when changing assignment targets", () => {
+    expect(updateStudioSceneAssignmentProfile({
+      profileId: "alpha",
+      overrides: { musicProgramId: "music-1" },
+    }, "beta")).toEqual({
+      profileId: "beta",
+      overrides: { musicProgramId: "music-1" },
+    });
+
+    expect(updateStudioSceneAssignmentProfile({
+      profileId: "alpha",
+      overrides: { ambienceLayerIds: ["wind"] },
+    }, null)).toEqual({
+      profileId: null,
+      overrides: { ambienceLayerIds: ["wind"] },
+    });
+  });
+
+  it("accepts a valid authored soundscape payload", async () => {
+    const profile = createSoundscapeProfile([]);
+    profile.musicPrograms["score"] = {
+      id: "score",
+      name: "Town Music",
+      playlistUuids: ["Playlist.playlist-1"],
+      selectionMode: "random",
+      delaySeconds: 12,
+    };
+    profile.ambienceLayers["wind"] = {
+      id: "wind",
+      name: "Cold Wind",
+      mode: "random",
+      soundUuids: ["PlaylistSound.wind"],
+      minDelaySeconds: 5,
+      maxDelaySeconds: 15,
+    };
+    profile.soundMoments["stinger"] = {
+      id: "stinger",
+      name: "Door Slam",
+      soundUuids: ["PlaylistSound.stinger"],
+      selectionMode: "single",
+    };
+    profile.rules = [
+      { id: "base", trigger: { type: "base" }, musicProgramId: "score", ambienceLayerIds: ["wind"] },
+      { id: "combat", trigger: { type: "combat" }, musicProgramId: null },
+      { id: "night", trigger: { type: "timeOfDay", timeOfDay: "night" }, ambienceLayerIds: ["wind"] },
+      { id: "storm", trigger: { type: "weather", weatherKeys: ["storm"] }, ambienceLayerIds: null },
+    ];
+
+    const snapshot = replaceProfileInLibrary(makeSnapshot(), profile);
+    const result = await validateSoundscapeStudioData(snapshot, profile.id, {
+      sceneA: { profileId: profile.id },
+    });
+
+    expect(result).toEqual({
+      isValid: true,
+      messages: [],
+    });
+  });
+
+  it("resolves preview from scene assignments and world default fallback", () => {
+    const directProfile = createSoundscapeProfile([], "Direct Score");
+    directProfile.musicPrograms["direct-score"] = {
+      id: "direct-score",
+      name: "Direct Score",
+      playlistUuids: ["Playlist.playlist-1"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    };
+    directProfile.rules = [{ id: "base", trigger: { type: "base" }, musicProgramId: "direct-score" }];
+
+    const worldProfile = createSoundscapeProfile([directProfile.id], "World Score");
+    worldProfile.musicPrograms["world-score"] = {
+      id: "world-score",
+      name: "World Score",
+      playlistUuids: ["Playlist.playlist-1"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    };
+    worldProfile.rules = [{ id: "base", trigger: { type: "base" }, musicProgramId: "world-score" }];
+
+    const snapshot = replaceProfileInLibrary(
+      replaceProfileInLibrary(makeSnapshot(), directProfile),
+      worldProfile,
+    );
+
+    expect(resolveSoundscapeStudioPreview({
+      library: snapshot,
+      selectedProfileId: directProfile.id,
+      previewSceneId: "scene-direct",
+      sceneAssignments: {
+        "scene-direct": { profileId: directProfile.id, overrides: { ambienceLayerIds: null } },
+        "scene-inherit": null,
+      },
+      worldDefaultProfileId: worldProfile.id,
+      context: {},
+    })?.profileId).toBe(directProfile.id);
+
+    expect(resolveSoundscapeStudioPreview({
+      library: snapshot,
+      selectedProfileId: directProfile.id,
+      previewSceneId: "scene-inherit",
+      sceneAssignments: {
+        "scene-direct": { profileId: directProfile.id },
+        "scene-inherit": null,
+      },
+      worldDefaultProfileId: worldProfile.id,
+      context: {},
+    })?.profileId).toBe(worldProfile.id);
+  });
+
+  it("reports malformed triggers, impossible timing, and missing references", async () => {
+    const profile = createSoundscapeProfile([]);
+    profile.musicPrograms["score"] = {
+      id: "score",
+      name: "Broken Music",
+      playlistUuids: ["Playlist.missing"],
+      selectionMode: "sequential",
+      delaySeconds: -2,
+    };
+    profile.ambienceLayers["wind"] = {
+      id: "wind",
+      name: "",
+      mode: "random",
+      soundUuids: ["PlaylistSound.missing"],
+      minDelaySeconds: 12,
+      maxDelaySeconds: 2,
+    };
+    profile.soundMoments["stinger"] = {
+      id: "stinger",
+      name: "",
+      soundUuids: [],
+      selectionMode: "random",
+    };
+    profile.rules = [
+      { id: "base", trigger: { type: "base" } },
+      { id: "base-2", trigger: { type: "base" }, musicProgramId: "ghost" },
+      { id: "storm-1", trigger: { type: "weather", weatherKeys: [] }, ambienceLayerIds: ["ghost-layer"] },
+      { id: "storm-2", trigger: { type: "weather", weatherKeys: [] }, ambienceLayerIds: ["ghost-layer"] },
+    ];
+
+    fromUuidMock.mockResolvedValue(null);
+
+    const snapshot = replaceProfileInLibrary(makeSnapshot(), profile);
+    const result = await validateSoundscapeStudioData(snapshot, "missing-default", {
+      sceneA: { profileId: "missing-scene-profile" },
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "worldDefaultProfileId" }),
+      expect.objectContaining({ path: "sceneAssignments.sceneA.profileId" }),
+      expect.objectContaining({ path: "rules", message: "Only one base rule is allowed per soundscape." }),
+      expect.objectContaining({ path: "profiles.new-soundscape.rules.0", message: "Trigger rules must override music, ambience, or both." }),
+      expect.objectContaining({ path: "profiles.new-soundscape.rules.1.musicProgramId" }),
+      expect.objectContaining({ path: "profiles.new-soundscape.rules.2", message: "Weather rules need at least one weather key." }),
+      expect.objectContaining({ path: "profiles.new-soundscape.rules.3", message: "Duplicate trigger rule detected for \"weather:\"." }),
+      expect.objectContaining({ path: "profiles.new-soundscape.musicPrograms.score.delaySeconds" }),
+      expect.objectContaining({ path: "profiles.new-soundscape.ambienceLayers.wind", message: "Ambience max delay must be greater than or equal to min delay." }),
+      expect.objectContaining({ path: "profiles.new-soundscape.soundMoments.stinger.soundUuids" }),
+    ]));
+  });
+});

--- a/src/soundscapes/soundscape-studio-helpers.ts
+++ b/src/soundscapes/soundscape-studio-helpers.ts
@@ -1,0 +1,471 @@
+import { fromUuid, getGame } from "../types";
+import {
+  type PersistentSoundscapeLibrarySnapshot,
+  type ResolvedSoundscapeState,
+  type SoundscapeAmbienceLayer,
+  type SoundscapeMusicProgram,
+  type SoundscapeProfile,
+  type SoundscapeRule,
+  type SoundscapeSceneAssignment,
+  type SoundscapeSoundMoment,
+  type SoundscapeTriggerContext,
+} from "./soundscape-types";
+import { normalizeSoundscapeProfile } from "./soundscape-normalization";
+import { resolveSoundscapeState } from "./soundscape-resolver";
+
+export interface SoundscapeStudioValidationMessage {
+  profileId?: string;
+  path: string;
+  message: string;
+}
+
+export interface SoundscapeStudioValidationResult {
+  isValid: boolean;
+  messages: SoundscapeStudioValidationMessage[];
+}
+
+interface SoundscapeStudioValidationOptions {
+  resolveUuid?: (uuid: string) => Promise<boolean>;
+  knownPlaylistUuids?: Iterable<string>;
+}
+
+function slugifySegment(value: string, fallback: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || fallback;
+}
+
+function uniqueId(baseId: string, existingIds: Iterable<string>): string {
+  const taken = new Set(existingIds);
+  if (!taken.has(baseId)) return baseId;
+
+  let index = 2;
+  while (taken.has(`${baseId}-${index}`)) index += 1;
+  return `${baseId}-${index}`;
+}
+
+function cloneProfile(profile: SoundscapeProfile): SoundscapeProfile {
+  return JSON.parse(JSON.stringify(profile)) as SoundscapeProfile;
+}
+
+function joinUuidList(values: string[]): string {
+  return values.join("\n");
+}
+
+function splitUuidList(value: string): string[] {
+  return value
+    .split(/\r?\n|,/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function getKnownPlaylistUuidSet(): Set<string> {
+  const playlists = getGame()?.playlists;
+  if (!playlists) return new Set<string>();
+
+  const uuids = new Set<string>();
+  for (const playlist of playlists) {
+    if (typeof playlist?.uuid === "string" && playlist.uuid.trim().length > 0) {
+      uuids.add(playlist.uuid.trim());
+    }
+  }
+  return uuids;
+}
+
+export function listKnownPlaylists(): Array<{ id: string; name: string; uuid: string }> {
+  const playlists = getGame()?.playlists;
+  if (!playlists) return [];
+
+  return [...playlists]
+    .map((playlist) => ({
+      id: playlist.id,
+      name: playlist.name?.trim() || "Untitled Playlist",
+      uuid: typeof playlist.uuid === "string" ? playlist.uuid.trim() : "",
+    }))
+    .filter((playlist) => playlist.uuid.length > 0)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function listSoundscapeProfiles(snapshot: PersistentSoundscapeLibrarySnapshot): SoundscapeProfile[] {
+  return Object.values(snapshot.profiles).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function listSoundscapeScenes(): Array<{ id: string; name: string; active: boolean }> {
+  const scenes = getGame()?.scenes;
+  if (!scenes) return [];
+
+  return [...scenes]
+    .map((scene) => ({
+      id: scene.id,
+      name: scene.name?.trim() || "Untitled Scene",
+      active: !!scene.active,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function createSoundscapeProfile(existingIds: Iterable<string>, name = "New Soundscape"): SoundscapeProfile {
+  const id = uniqueId(slugifySegment(name, "soundscape-profile"), existingIds);
+  return normalizeSoundscapeProfile({
+    id,
+    name,
+    musicPrograms: {},
+    ambienceLayers: {},
+    soundMoments: {},
+    rules: [{ id: "base", trigger: { type: "base" } }],
+  }, id);
+}
+
+export function duplicateSoundscapeProfile(profile: SoundscapeProfile, existingIds: Iterable<string>): SoundscapeProfile {
+  const nextId = uniqueId(slugifySegment(`${profile.id}-copy`, "soundscape-profile-copy"), existingIds);
+  return normalizeSoundscapeProfile({
+    ...cloneProfile(profile),
+    id: nextId,
+    name: `${profile.name} Copy`,
+  }, nextId);
+}
+
+export function createSoundscapeMusicProgram(existingIds: Iterable<string>, name = "New Music Program"): SoundscapeMusicProgram {
+  const id = uniqueId(slugifySegment(name, "music-program"), existingIds);
+  return {
+    id,
+    name,
+    playlistUuids: [],
+    selectionMode: "sequential",
+    delaySeconds: 0,
+  };
+}
+
+export function createSoundscapeAmbienceLayer(existingIds: Iterable<string>, name = "New Ambience Layer"): SoundscapeAmbienceLayer {
+  const id = uniqueId(slugifySegment(name, "ambience-layer"), existingIds);
+  return {
+    id,
+    name,
+    mode: "loop",
+    soundUuids: [],
+    minDelaySeconds: 0,
+    maxDelaySeconds: 0,
+  };
+}
+
+export function createSoundscapeSoundMoment(existingIds: Iterable<string>, name = "New Sound Moment"): SoundscapeSoundMoment {
+  const id = uniqueId(slugifySegment(name, "sound-moment"), existingIds);
+  return {
+    id,
+    name,
+    soundUuids: [],
+    selectionMode: "single",
+  };
+}
+
+export function createSoundscapeRule(existingIds: Iterable<string>): SoundscapeRule {
+  return {
+    id: uniqueId("soundscape-rule", existingIds),
+    trigger: { type: "manualPreview" },
+  };
+}
+
+export function replaceProfileInLibrary(
+  snapshot: PersistentSoundscapeLibrarySnapshot,
+  profile: SoundscapeProfile,
+): PersistentSoundscapeLibrarySnapshot {
+  return {
+    ...snapshot,
+    profiles: {
+      ...snapshot.profiles,
+      [profile.id]: cloneProfile(profile),
+    },
+  };
+}
+
+export function removeProfileFromLibrary(
+  snapshot: PersistentSoundscapeLibrarySnapshot,
+  profileId: string,
+): PersistentSoundscapeLibrarySnapshot {
+  const profiles = { ...snapshot.profiles };
+  delete profiles[profileId];
+  return {
+    ...snapshot,
+    profiles,
+  };
+}
+
+export function sanitizeSceneAssignmentsForProfileDeletion(
+  assignments: Record<string, SoundscapeSceneAssignment | null>,
+  deletedProfileId: string,
+): Record<string, SoundscapeSceneAssignment | null> {
+  return Object.fromEntries(
+    Object.entries(assignments).map(([sceneId, assignment]) => {
+      if (!assignment || assignment.profileId !== deletedProfileId) return [sceneId, assignment];
+      return [sceneId, null];
+    }),
+  );
+}
+
+export function updateStudioSceneAssignmentProfile(
+  assignment: SoundscapeSceneAssignment | null | undefined,
+  profileId: string | null,
+): SoundscapeSceneAssignment | null {
+  const nextProfileId = profileId?.trim() || null;
+  if (nextProfileId) {
+    return assignment?.overrides
+      ? { profileId: nextProfileId, overrides: assignment.overrides }
+      : { profileId: nextProfileId };
+  }
+
+  return assignment?.overrides
+    ? { profileId: null, overrides: assignment.overrides }
+    : null;
+}
+
+export function parseUuidText(value: string): string[] {
+  return splitUuidList(value);
+}
+
+export function stringifyUuidText(values: string[]): string {
+  return joinUuidList(values);
+}
+
+export function resolveSoundscapeStudioPreview(input: {
+  library: PersistentSoundscapeLibrarySnapshot;
+  selectedProfileId: string | null;
+  previewSceneId: string | null;
+  sceneAssignments: Record<string, SoundscapeSceneAssignment | null>;
+  worldDefaultProfileId: string | null;
+  context: Partial<SoundscapeTriggerContext>;
+}): ResolvedSoundscapeState | null {
+  const previewAssignment = input.previewSceneId
+    ? (input.sceneAssignments[input.previewSceneId] ?? null)
+    : (input.selectedProfileId ? { profileId: input.selectedProfileId } : null);
+
+  return resolveSoundscapeState({
+    library: input.library,
+    sceneAssignment: previewAssignment,
+    worldDefaultProfileId: input.worldDefaultProfileId,
+    context: input.context,
+    sceneId: input.previewSceneId,
+  });
+}
+
+export async function validateSoundscapeStudioData(
+  snapshot: PersistentSoundscapeLibrarySnapshot,
+  worldDefaultProfileId: string | null,
+  sceneAssignments: Record<string, SoundscapeSceneAssignment | null>,
+  options: SoundscapeStudioValidationOptions = {},
+): Promise<SoundscapeStudioValidationResult> {
+  const messages: SoundscapeStudioValidationMessage[] = [];
+  const knownPlaylistUuids = new Set(options.knownPlaylistUuids ?? getKnownPlaylistUuidSet());
+  const resolveUuid = options.resolveUuid ?? (async (uuid: string) => (await fromUuid(uuid)) !== null);
+  const profiles = Object.values(snapshot.profiles);
+  const profileIds = new Set(profiles.map((profile) => profile.id));
+
+  if (worldDefaultProfileId && !profileIds.has(worldDefaultProfileId)) {
+    messages.push({
+      path: "worldDefaultProfileId",
+      message: "World default profile must reference an existing soundscape.",
+    });
+  }
+
+  for (const [sceneId, assignment] of Object.entries(sceneAssignments)) {
+    if (!assignment?.profileId) continue;
+    if (!profileIds.has(assignment.profileId)) {
+      messages.push({
+        path: `sceneAssignments.${sceneId}.profileId`,
+        message: `Scene assignment references missing profile "${assignment.profileId}".`,
+      });
+    }
+  }
+
+  const uniqueAssetUuids = new Map<string, string[]>();
+  const queueAssetCheck = (uuid: string, path: string): void => {
+    const paths = uniqueAssetUuids.get(uuid) ?? [];
+    paths.push(path);
+    uniqueAssetUuids.set(uuid, paths);
+  };
+
+  for (const profile of profiles) {
+    const rules = profile.rules;
+    const baseRules = rules.filter((rule) => rule.trigger.type === "base");
+
+    if (baseRules.length === 0) {
+      messages.push({
+        profileId: profile.id,
+        path: "rules",
+        message: "Each soundscape needs a base rule.",
+      });
+    }
+
+    if (baseRules.length > 1) {
+      messages.push({
+        profileId: profile.id,
+        path: "rules",
+        message: "Only one base rule is allowed per soundscape.",
+      });
+    }
+
+    const triggerSignatures = new Set<string>();
+    for (const [index, rule] of rules.entries()) {
+      const prefix = `profiles.${profile.id}.rules.${index}`;
+      const signature = (() => {
+        if (rule.trigger.type === "weather") {
+          return `weather:${[...(rule.trigger.weatherKeys ?? [])].sort().join("|")}`;
+        }
+        if (rule.trigger.type === "timeOfDay") return `timeOfDay:${rule.trigger.timeOfDay}`;
+        return rule.trigger.type;
+      })();
+
+      if (triggerSignatures.has(signature)) {
+        messages.push({
+          profileId: profile.id,
+          path: prefix,
+          message: `Duplicate trigger rule detected for "${signature}".`,
+        });
+      } else {
+        triggerSignatures.add(signature);
+      }
+
+      if (rule.trigger.type === "weather" && rule.trigger.weatherKeys.length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: prefix,
+          message: "Weather rules need at least one weather key.",
+        });
+      }
+
+      const musicProgramIdDefined = Object.prototype.hasOwnProperty.call(rule, "musicProgramId");
+      const ambienceLayerIdsDefined = Object.prototype.hasOwnProperty.call(rule, "ambienceLayerIds");
+      if (!musicProgramIdDefined && !ambienceLayerIdsDefined) {
+        messages.push({
+          profileId: profile.id,
+          path: prefix,
+          message: "Trigger rules must override music, ambience, or both.",
+        });
+      }
+
+      if (typeof rule.musicProgramId === "string" && !(rule.musicProgramId in profile.musicPrograms)) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.musicProgramId`,
+          message: `Rule references missing music program "${rule.musicProgramId}".`,
+        });
+      }
+
+      if (Array.isArray(rule.ambienceLayerIds)) {
+        for (const ambienceLayerId of rule.ambienceLayerIds) {
+          if (!(ambienceLayerId in profile.ambienceLayers)) {
+            messages.push({
+              profileId: profile.id,
+              path: `${prefix}.ambienceLayerIds`,
+              message: `Rule references missing ambience layer "${ambienceLayerId}".`,
+            });
+          }
+        }
+      }
+    }
+
+    for (const program of Object.values(profile.musicPrograms)) {
+      const prefix = `profiles.${profile.id}.musicPrograms.${program.id}`;
+      if (program.name.trim().length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.name`,
+          message: "Music programs need a name.",
+        });
+      }
+      if (program.delaySeconds < 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.delaySeconds`,
+          message: "Music delay cannot be negative.",
+        });
+      }
+      if (program.playlistUuids.length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.playlistUuids`,
+          message: "Music programs need at least one playlist UUID.",
+        });
+      }
+      for (const playlistUuid of program.playlistUuids) {
+        if (!knownPlaylistUuids.has(playlistUuid)) {
+          queueAssetCheck(playlistUuid, `${prefix}.playlistUuids`);
+        }
+      }
+    }
+
+    for (const layer of Object.values(profile.ambienceLayers)) {
+      const prefix = `profiles.${profile.id}.ambienceLayers.${layer.id}`;
+      if (layer.name.trim().length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.name`,
+          message: "Ambience layers need a name.",
+        });
+      }
+      if (layer.minDelaySeconds < 0 || layer.maxDelaySeconds < 0) {
+        messages.push({
+          profileId: profile.id,
+          path: prefix,
+          message: "Ambience timing values cannot be negative.",
+        });
+      }
+      if (layer.maxDelaySeconds < layer.minDelaySeconds) {
+        messages.push({
+          profileId: profile.id,
+          path: prefix,
+          message: "Ambience max delay must be greater than or equal to min delay.",
+        });
+      }
+      if (layer.soundUuids.length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.soundUuids`,
+          message: "Ambience layers need at least one sound UUID.",
+        });
+      }
+      for (const soundUuid of layer.soundUuids) {
+        queueAssetCheck(soundUuid, `${prefix}.soundUuids`);
+      }
+    }
+
+    for (const moment of Object.values(profile.soundMoments)) {
+      const prefix = `profiles.${profile.id}.soundMoments.${moment.id}`;
+      if (moment.name.trim().length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.name`,
+          message: "Sound moments need a name.",
+        });
+      }
+      if (moment.soundUuids.length === 0) {
+        messages.push({
+          profileId: profile.id,
+          path: `${prefix}.soundUuids`,
+          message: "Sound moments need at least one sound UUID.",
+        });
+      }
+      for (const soundUuid of moment.soundUuids) {
+        queueAssetCheck(soundUuid, `${prefix}.soundUuids`);
+      }
+    }
+  }
+
+  for (const [uuid, paths] of uniqueAssetUuids.entries()) {
+    const exists = await resolveUuid(uuid);
+    if (exists) continue;
+
+    for (const path of paths) {
+      messages.push({
+        path,
+        message: `Referenced UUID "${uuid}" could not be resolved.`,
+      });
+    }
+  }
+
+  return {
+    isValid: messages.length === 0,
+    messages,
+  };
+}

--- a/templates/soundscapes/soundscape-studio-root.hbs
+++ b/templates/soundscapes/soundscape-studio-root.hbs
@@ -1,0 +1,1 @@
+<div class="fth-react-app-shell fth-ui-root" data-fth-react-root></div>


### PR DESCRIPTION
## Summary
- add a dedicated GM Soundscape Studio ApplicationV2 + React workflow
- support soundscape authoring, validation, preview, and scene/world assignment management
- expose `window.fth.soundscapes.openStudio()` and add a GM scene-control entry point

## Verification
- npm run typecheck
- npx vitest run src/soundscapes/soundscape-studio-helpers.test.ts src/soundscapes/soundscape-studio-app.test.tsx src/index.test.ts src/fth-api.test.ts
- npm run test
- npm run build

Closes #70
