### PR TITLE
Implement reactive soundscapes adaptive music runtime

### DIFF
--- a/src/fth-api.test.ts
+++ b/src/fth-api.test.ts
@@ -16,6 +16,9 @@ const buildSoundscapeApiMock = vi.fn(() => ({
     getLibrary: vi.fn(),
     resolve: vi.fn(),
     openStudio: vi.fn(),
+    syncMusic: vi.fn(async () => ({})),
+    stopMusic: vi.fn(async () => {}),
+    getMusicState: vi.fn(() => ({})),
   },
 }));
 
@@ -77,6 +80,9 @@ describe("fth api", () => {
     api.soundscapes.getLibrary();
     api.soundscapes.resolve();
     api.soundscapes.openStudio();
+    await api.soundscapes.syncMusic();
+    await api.soundscapes.stopMusic();
+    api.soundscapes.getMusicState();
 
     expect(setLevelMock).toHaveBeenCalledWith("debug");
     expect(openAssetManagerMock).toHaveBeenCalledTimes(1);

--- a/src/soundscapes/soundscape-api.ts
+++ b/src/soundscapes/soundscape-api.ts
@@ -1,11 +1,20 @@
 import type { PersistentSoundscapeLibrarySnapshot, ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
 import { getStoredSoundscapeLibrarySnapshot, resolveStoredSoundscapeState } from "./soundscape-accessors";
+import {
+  getSoundscapeMusicRuntimeSnapshot,
+  stopStoredSoundscapeMusic,
+  syncStoredSoundscapeMusic,
+} from "./soundscape-music-controller";
+import type { SoundscapeMusicRuntimeSnapshot } from "./soundscape-music-runtime";
 import { openSoundscapeStudio } from "./soundscape-studio-app";
 
 export interface FthSoundscapeDebugApi {
   getLibrary: () => PersistentSoundscapeLibrarySnapshot | null;
   resolve: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => ResolvedSoundscapeState | null;
   openStudio: () => void;
+  syncMusic: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => Promise<SoundscapeMusicRuntimeSnapshot>;
+  stopMusic: () => Promise<void>;
+  getMusicState: () => SoundscapeMusicRuntimeSnapshot;
 }
 
 export interface FthSoundscapeApi {
@@ -18,6 +27,9 @@ export function buildSoundscapeApi(): FthSoundscapeApi {
       getLibrary: () => getStoredSoundscapeLibrarySnapshot(),
       resolve: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => resolveStoredSoundscapeState(sceneId, context),
       openStudio: () => openSoundscapeStudio(),
+      syncMusic: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => syncStoredSoundscapeMusic(sceneId, context),
+      stopMusic: () => stopStoredSoundscapeMusic(),
+      getMusicState: () => getSoundscapeMusicRuntimeSnapshot(),
     },
   };
 }

--- a/src/soundscapes/soundscape-music-controller.test.ts
+++ b/src/soundscapes/soundscape-music-controller.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveStoredSoundscapeStateMock = vi.fn();
+const getHooksMock = vi.fn();
+const runtimeSyncMock = vi.fn();
+const runtimeStopMock = vi.fn();
+const runtimeGetSnapshotMock = vi.fn(() => ({
+  activeProgramKey: null,
+  activeProgramId: null,
+  activePlaylistUuid: null,
+  activeSoundId: null,
+  pendingProgramKey: null,
+  pendingDelayMs: null,
+  lastError: null,
+}));
+const runtimeHandleTrackEndedMock = vi.fn();
+
+vi.mock("./soundscape-accessors", () => ({
+  resolveStoredSoundscapeState: resolveStoredSoundscapeStateMock,
+}));
+
+vi.mock("../types", () => ({
+  getHooks: getHooksMock,
+}));
+
+vi.mock("./soundscape-music-runtime", () => ({
+  SoundscapeMusicRuntime: class {
+    sync = runtimeSyncMock;
+    stop = runtimeStopMock;
+    getSnapshot = runtimeGetSnapshotMock;
+    handleTrackEnded = runtimeHandleTrackEndedMock;
+  },
+}));
+
+describe("soundscape music controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveStoredSoundscapeStateMock.mockReturnValue({ musicProgramId: "calm" });
+    runtimeSyncMock.mockResolvedValue({
+      activeProgramKey: "forest:calm",
+      activeProgramId: "calm",
+      activePlaylistUuid: "Playlist.calm",
+      activeSoundId: "track-1",
+      pendingProgramKey: null,
+      pendingDelayMs: null,
+      lastError: null,
+    });
+    runtimeStopMock.mockResolvedValue(undefined);
+    getHooksMock.mockReturnValue({ on: vi.fn() });
+  });
+
+  it("resolves stored state and hands it to the singleton runtime", async () => {
+    const mod = await import("./soundscape-music-controller");
+
+    await mod.syncStoredSoundscapeMusic("scene-1", { inCombat: true });
+
+    expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", { inCombat: true });
+    expect(runtimeSyncMock).toHaveBeenCalledWith({ musicProgramId: "calm" });
+    expect(getHooksMock().on).toHaveBeenCalledWith("updatePlaylistSound", expect.any(Function));
+  });
+
+  it("stops playback and exposes the runtime snapshot", async () => {
+    const mod = await import("./soundscape-music-controller");
+
+    await mod.stopStoredSoundscapeMusic();
+
+    expect(runtimeStopMock).toHaveBeenCalledTimes(1);
+    expect(mod.getSoundscapeMusicRuntimeSnapshot()).toEqual(runtimeGetSnapshotMock.mock.results[0]?.value);
+  });
+
+  it("treats updatePlaylistSound playback-off transitions as track completion", async () => {
+    const mod = await import("./soundscape-music-controller");
+    const controller = mod.__soundscapeMusicControllerInternals.singletonController as {
+      handlePlaylistSoundUpdate(
+        sound: {
+          id: string;
+          playing?: boolean;
+          parent?: { id?: string; uuid?: string };
+        },
+        changed: Record<string, unknown>,
+      ): void;
+    };
+
+    controller.handlePlaylistSoundUpdate({ id: "track-1", playing: false, parent: { id: "playlist-1", uuid: "Playlist.playlist-1" } }, {});
+    controller.handlePlaylistSoundUpdate({ id: "track-1", playing: true, parent: { id: "playlist-1", uuid: "Playlist.playlist-1" } }, { playing: false });
+    controller.handlePlaylistSoundUpdate({ id: "track-1", playing: true, parent: { id: "playlist-1", uuid: "Playlist.playlist-1" } }, { playing: true });
+
+    expect(runtimeHandleTrackEndedMock).toHaveBeenCalledTimes(2);
+    expect(runtimeHandleTrackEndedMock).toHaveBeenNthCalledWith(1, {
+      playlistId: "playlist-1",
+      playlistUuid: "Playlist.playlist-1",
+      soundId: "track-1",
+    });
+    expect(runtimeHandleTrackEndedMock).toHaveBeenNthCalledWith(2, {
+      playlistId: "playlist-1",
+      playlistUuid: "Playlist.playlist-1",
+      soundId: "track-1",
+    });
+  });
+});

--- a/src/soundscapes/soundscape-music-controller.ts
+++ b/src/soundscapes/soundscape-music-controller.ts
@@ -1,0 +1,85 @@
+import { getHooks } from "../types";
+import { resolveStoredSoundscapeState } from "./soundscape-accessors";
+import {
+  SoundscapeMusicRuntime,
+  type SoundscapeMusicRuntimeSnapshot,
+} from "./soundscape-music-runtime";
+import type { ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
+
+interface PlaylistSoundUpdateLike {
+  id: string;
+  playing?: boolean;
+  parent?: {
+    id?: string;
+    uuid?: string;
+  } | null;
+}
+
+class SoundscapeMusicController {
+  private readonly runtime: SoundscapeMusicRuntime;
+  private hooksRegistered = false;
+
+  constructor(runtime = new SoundscapeMusicRuntime()) {
+    this.runtime = runtime;
+  }
+
+  async syncResolvedState(state: ResolvedSoundscapeState | null): Promise<SoundscapeMusicRuntimeSnapshot> {
+    this.ensureHooksRegistered();
+    return await this.runtime.sync(state);
+  }
+
+  async syncStoredState(
+    sceneId?: string,
+    context?: Partial<SoundscapeTriggerContext>,
+  ): Promise<SoundscapeMusicRuntimeSnapshot> {
+    return await this.syncResolvedState(resolveStoredSoundscapeState(sceneId, context));
+  }
+
+  async stop(): Promise<void> {
+    await this.runtime.stop();
+  }
+
+  getSnapshot(): SoundscapeMusicRuntimeSnapshot {
+    return this.runtime.getSnapshot();
+  }
+
+  handlePlaylistSoundUpdate(sound: PlaylistSoundUpdateLike, changed: Record<string, unknown> | null | undefined): void {
+    const playingChanged = typeof changed?.playing === "boolean" ? changed.playing : undefined;
+    const isNowStopped = playingChanged === false || (playingChanged === undefined && sound.playing === false);
+    if (!isNowStopped) return;
+    this.runtime.handleTrackEnded({
+      playlistUuid: sound.parent?.uuid ?? null,
+      playlistId: sound.parent?.id ?? null,
+      soundId: sound.id,
+    });
+  }
+
+  private ensureHooksRegistered(): void {
+    if (this.hooksRegistered) return;
+    getHooks()?.on?.("updatePlaylistSound", (sound: PlaylistSoundUpdateLike, changed: Record<string, unknown>) => {
+      this.handlePlaylistSoundUpdate(sound, changed);
+    });
+    this.hooksRegistered = true;
+  }
+}
+
+const singletonController = new SoundscapeMusicController();
+
+export async function syncStoredSoundscapeMusic(
+  sceneId?: string,
+  context?: Partial<SoundscapeTriggerContext>,
+): Promise<SoundscapeMusicRuntimeSnapshot> {
+  return await singletonController.syncStoredState(sceneId, context);
+}
+
+export async function stopStoredSoundscapeMusic(): Promise<void> {
+  await singletonController.stop();
+}
+
+export function getSoundscapeMusicRuntimeSnapshot(): SoundscapeMusicRuntimeSnapshot {
+  return singletonController.getSnapshot();
+}
+
+export const __soundscapeMusicControllerInternals = {
+  singletonController,
+};

--- a/src/soundscapes/soundscape-music-runtime.test.ts
+++ b/src/soundscapes/soundscape-music-runtime.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveMusicTrackCandidates, SoundscapeMusicRuntime } from "./soundscape-music-runtime";
+import type { ResolvedSoundscapeState, SoundscapeMusicProgram } from "./soundscape-types";
+
+interface FakeTimerHandle {
+  callback: () => void;
+  delay: number;
+  cleared: boolean;
+}
+
+interface FakePlaylistSound {
+  id: string;
+  uuid?: string;
+  name?: string;
+  path?: string;
+  sort?: number;
+  playing?: boolean;
+  repeat?: boolean;
+  load?: () => Promise<void>;
+  sync?: () => void;
+}
+
+interface FakePlaylist {
+  id: string;
+  uuid: string;
+  name: string;
+  sounds: FakePlaylistSound[];
+  playSound: (sound: FakePlaylistSound) => Promise<unknown>;
+  stopSound?: (sound: FakePlaylistSound) => Promise<unknown>;
+  stopAll?: () => Promise<unknown>;
+}
+
+function createFakeTimers() {
+  const handles: FakeTimerHandle[] = [];
+  return {
+    handles,
+    api: {
+      setTimeout(callback: () => void, delay: number) {
+        const handle = { callback, delay, cleared: false };
+        handles.push(handle);
+        return handle;
+      },
+      clearTimeout(handle: unknown) {
+        const timer = handle as FakeTimerHandle | undefined;
+        if (timer) timer.cleared = true;
+      },
+    },
+    runNext() {
+      const handle = handles.find((entry) => !entry.cleared);
+      if (!handle) return;
+      handle.cleared = true;
+      handle.callback();
+    },
+  };
+}
+
+function createPlaylist(
+  uuid: string,
+  name: string,
+  soundIds: string[],
+): FakePlaylist {
+  const sounds = soundIds.map((soundId, index) => {
+    const load = vi.fn(async (): Promise<void> => {});
+    const sync = vi.fn((): void => {});
+
+    return {
+      id: soundId,
+      uuid: `${uuid}.${soundId}`,
+      name: soundId,
+      path: `sounds/${soundId}.ogg`,
+      sort: index,
+      load,
+      sync,
+    };
+  });
+
+  const playSound = vi.fn(async (_sound: FakePlaylistSound): Promise<void> => {});
+  const stopSound = vi.fn(async (_sound: FakePlaylistSound): Promise<void> => {});
+
+  return {
+    id: uuid.split(".").at(-1) ?? uuid,
+    uuid,
+    name,
+    sounds,
+    playSound,
+    stopSound,
+  };
+}
+
+function createResolvedState(program: SoundscapeMusicProgram): ResolvedSoundscapeState {
+  return {
+    profileId: "forest",
+    assignmentSource: "worldDefault",
+    sceneId: "scene-1",
+    context: {
+      manualPreview: false,
+      inCombat: false,
+      weather: null,
+      timeOfDay: null,
+    },
+    musicProgramId: program.id,
+    musicProgram: program,
+    musicRuleId: "base",
+    ambienceLayerIds: [],
+    ambienceLayers: [],
+    ambienceRuleId: null,
+    soundMoments: [],
+  };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("soundscape music runtime", () => {
+  it("flattens authored playlists into deterministic track candidates", async () => {
+    const town = createPlaylist("Playlist.town", "Town", ["a", "b"]);
+    const battle = createPlaylist("Playlist.battle", "Battle", ["c"]);
+
+    const candidates = await resolveMusicTrackCandidates({
+      id: "program",
+      name: "Program",
+      playlistUuids: ["Playlist.town", "Playlist.battle"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }, async (uuid) => {
+      if (uuid === "Playlist.town") return town;
+      if (uuid === "Playlist.battle") return battle;
+      return null;
+    });
+
+    expect(candidates.map((candidate) => `${candidate.playlistUuid}:${candidate.soundId}`)).toEqual([
+      "Playlist.town:a",
+      "Playlist.town:b",
+      "Playlist.battle:c",
+    ]);
+  });
+
+  it("plays sequential tracks and respects cooldown before the next track", async () => {
+    const timers = createFakeTimers();
+    const playlist = createPlaylist("Playlist.town", "Town", ["a", "b"]);
+    const program: SoundscapeMusicProgram = {
+      id: "calm",
+      name: "Calm",
+      playlistUuids: ["Playlist.town"],
+      selectionMode: "sequential",
+      delaySeconds: 5,
+    };
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async () => playlist,
+      timers: timers.api,
+    });
+
+    await runtime.sync(createResolvedState(program));
+
+    expect(playlist.playSound).toHaveBeenCalledTimes(1);
+    expect(playlist.playSound).toHaveBeenLastCalledWith(playlist.sounds[0]);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeProgramId: "calm",
+      activeSoundId: "a",
+      pendingDelayMs: null,
+    });
+
+    runtime.handleTrackEnded({ playlistUuid: "Playlist.town", playlistId: playlist.id, soundId: "a" });
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeSoundId: null,
+      pendingDelayMs: 5000,
+    });
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    expect(playlist.playSound).toHaveBeenCalledTimes(2);
+    expect(playlist.playSound).toHaveBeenLastCalledWith(playlist.sounds[1]);
+  });
+
+  it("uses deterministic random selection without repeating immediately when alternatives exist", async () => {
+    const playlist = createPlaylist("Playlist.town", "Town", ["a", "b", "c"]);
+    const rngValues = [0, 0];
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async () => playlist,
+      random: () => rngValues.shift() ?? 0,
+    });
+    const program: SoundscapeMusicProgram = {
+      id: "wild",
+      name: "Wild",
+      playlistUuids: ["Playlist.town"],
+      selectionMode: "random",
+      delaySeconds: 0,
+    };
+
+    await runtime.sync(createResolvedState(program));
+    runtime.handleTrackEnded({ playlistUuid: "Playlist.town", playlistId: playlist.id, soundId: "a" });
+    await flushAsyncWork();
+
+  const playedIds = ((playlist.playSound as unknown as { mock: { calls: unknown[][] } }).mock.calls)
+    .map((call) => (call[0] as { id: string }).id);
+    expect(playedIds).toEqual(["a", "b"]);
+  });
+
+  it("ignores track-ended updates from a different playlist with the same local sound id", async () => {
+    const firstPlaylist = createPlaylist("Playlist.one", "One", ["shared"]);
+    const secondPlaylist = createPlaylist("Playlist.two", "Two", ["shared"]);
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async (uuid) => uuid === "Playlist.one" ? firstPlaylist : secondPlaylist,
+    });
+
+    await runtime.sync(createResolvedState({
+      id: "calm",
+      name: "Calm",
+      playlistUuids: ["Playlist.one"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }));
+
+    runtime.handleTrackEnded({
+      playlistUuid: "Playlist.two",
+      playlistId: secondPlaylist.id,
+      soundId: "shared",
+    });
+    await flushAsyncWork();
+
+    expect(firstPlaylist.playSound).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activePlaylistUuid: "Playlist.one",
+      activeSoundId: "shared",
+      pendingDelayMs: null,
+    });
+  });
+
+  it("clears pending timers and stops old playback when switching programs", async () => {
+    const timers = createFakeTimers();
+    const calmPlaylist = createPlaylist("Playlist.calm", "Calm", ["calm-a"]);
+    const battlePlaylist = createPlaylist("Playlist.battle", "Battle", ["battle-a"]);
+
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async (uuid) => {
+        if (uuid === "Playlist.calm") return calmPlaylist;
+        if (uuid === "Playlist.battle") return battlePlaylist;
+        return null;
+      },
+      timers: timers.api,
+    });
+
+    await runtime.sync(createResolvedState({
+      id: "calm",
+      name: "Calm",
+      playlistUuids: ["Playlist.calm"],
+      selectionMode: "sequential",
+      delaySeconds: 10,
+    }));
+
+    await runtime.sync(createResolvedState({
+      id: "battle",
+      name: "Battle",
+      playlistUuids: ["Playlist.battle"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }));
+
+    expect(calmPlaylist.stopSound).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeProgramId: "battle",
+      pendingDelayMs: null,
+      activeSoundId: "battle-a",
+    });
+
+    timers.runNext();
+    expect(battlePlaylist.playSound).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores one stale end event when a program switch restarts the same track", async () => {
+    let now = 0;
+    const playlist = createPlaylist("Playlist.shared", "Shared", ["shared"]);
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async () => playlist,
+      now: () => now,
+    });
+
+    await runtime.sync(createResolvedState({
+      id: "calm",
+      name: "Calm",
+      playlistUuids: ["Playlist.shared"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }));
+
+    await runtime.sync(createResolvedState({
+      id: "battle",
+      name: "Battle",
+      playlistUuids: ["Playlist.shared"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }));
+
+    runtime.handleTrackEnded({
+      playlistUuid: "Playlist.shared",
+      playlistId: playlist.id,
+      soundId: "shared",
+    });
+    await flushAsyncWork();
+
+    expect((playlist.playSound as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(2);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeProgramId: "battle",
+      activePlaylistUuid: "Playlist.shared",
+      activeSoundId: "shared",
+      pendingDelayMs: null,
+    });
+
+    now = 2_000;
+    runtime.handleTrackEnded({
+      playlistUuid: "Playlist.shared",
+      playlistId: playlist.id,
+      soundId: "shared",
+    });
+    await flushAsyncWork();
+
+    expect((playlist.playSound as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(3);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeProgramId: "battle",
+      activePlaylistUuid: "Playlist.shared",
+      activeSoundId: "shared",
+      pendingDelayMs: null,
+    });
+  });
+
+  it("falls back to stopAll when a playlist cannot stop an individual sound", async () => {
+    const playlist = createPlaylist("Playlist.calm", "Calm", ["calm-a"]);
+    const stopAll = vi.fn(async () => {});
+    playlist.stopSound = undefined;
+    playlist.stopAll = stopAll;
+
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async () => playlist,
+    });
+
+    await runtime.sync(createResolvedState({
+      id: "calm",
+      name: "Calm",
+      playlistUuids: ["Playlist.calm"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }));
+    await runtime.stop();
+
+    expect(stopAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails gracefully when music program playlists cannot be resolved", async () => {
+    const runtime = new SoundscapeMusicRuntime({
+      getPlaylistByUuid: async () => null,
+    });
+
+    await runtime.sync(createResolvedState({
+      id: "missing",
+      name: "Missing",
+      playlistUuids: ["Playlist.missing"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    }));
+
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeProgramId: "missing",
+      activeSoundId: null,
+      lastError: 'No valid playlist tracks could be resolved for music program "Missing".',
+    });
+  });
+});

--- a/src/soundscapes/soundscape-music-runtime.ts
+++ b/src/soundscapes/soundscape-music-runtime.ts
@@ -1,0 +1,390 @@
+import { fromUuid, getGame } from "../types";
+import type {
+  ResolvedSoundscapeState,
+  SoundscapeMusicProgram,
+} from "./soundscape-types";
+
+interface TimerApi {
+  setTimeout(callback: () => void, delay: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+interface RuntimeDeps {
+  getPlaylistByUuid?: (uuid: string) => Promise<RuntimePlaylistLike | null>;
+  timers?: TimerApi;
+  random?: () => number;
+  now?: () => number;
+}
+
+interface RuntimePlaylistLike {
+  id: string;
+  uuid?: string;
+  name?: string;
+  sounds?: Iterable<RuntimePlaylistSoundLike>;
+  playSound?: (sound: RuntimePlaylistSoundLike) => Promise<unknown>;
+  stopSound?: (sound: RuntimePlaylistSoundLike) => Promise<unknown>;
+  stopAll?: () => Promise<unknown>;
+}
+
+interface RuntimePlaylistSoundLike {
+  id: string;
+  uuid?: string;
+  name?: string;
+  path?: string;
+  sort?: number;
+  playing?: boolean;
+  repeat?: boolean;
+  load?: () => Promise<void>;
+  sync?: () => void;
+}
+
+export interface SoundscapeMusicTrackCandidate {
+  playlistId: string;
+  playlistUuid: string;
+  playlistName: string;
+  soundId: string;
+  soundUuid: string | null;
+  soundName: string;
+  sort: number;
+  playlist: RuntimePlaylistLike;
+  sound: RuntimePlaylistSoundLike;
+}
+
+export interface SoundscapeMusicRuntimeSnapshot {
+  activeProgramKey: string | null;
+  activeProgramId: string | null;
+  activePlaylistUuid: string | null;
+  activeSoundId: string | null;
+  pendingProgramKey: string | null;
+  pendingDelayMs: number | null;
+  lastError: string | null;
+}
+
+export interface SoundscapeEndedTrackRef {
+  playlistUuid?: string | null;
+  playlistId?: string | null;
+  soundId: string;
+}
+
+interface ActiveProgramContext {
+  key: string;
+  program: SoundscapeMusicProgram;
+  profileId: string;
+}
+
+interface CandidateIdentity {
+  playlistId: string;
+  playlistUuid: string;
+  soundId: string;
+}
+
+interface IgnoredEndedTrack {
+  key: string;
+  ignoreUntil: number;
+}
+
+const PROGRAM_SWITCH_STALE_END_GRACE_MS = 1_000;
+
+const DEFAULT_TIMERS: TimerApi = {
+  setTimeout: (callback, delay) => globalThis.setTimeout(callback, delay),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function sortPlaylistSounds(sounds: RuntimePlaylistSoundLike[]): RuntimePlaylistSoundLike[] {
+  return [...sounds].sort((left, right) => {
+    const sortDelta = (left.sort ?? 0) - (right.sort ?? 0);
+    if (sortDelta !== 0) return sortDelta;
+    const nameDelta = (left.name ?? "").localeCompare(right.name ?? "");
+    if (nameDelta !== 0) return nameDelta;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function createProgramKey(profileId: string, musicProgramId: string): string {
+  return `${profileId}:${musicProgramId}`;
+}
+
+async function defaultGetPlaylistByUuid(uuid: string): Promise<RuntimePlaylistLike | null> {
+  const playlists = getGame()?.playlists;
+  if (playlists) {
+    for (const playlist of playlists) {
+      if (playlist.uuid === uuid) return playlist as RuntimePlaylistLike;
+    }
+  }
+
+  const resolved = await fromUuid(uuid);
+  if (!resolved) return null;
+  return resolved as RuntimePlaylistLike;
+}
+
+export async function resolveMusicTrackCandidates(
+  program: SoundscapeMusicProgram,
+  getPlaylistByUuid: (uuid: string) => Promise<RuntimePlaylistLike | null> = defaultGetPlaylistByUuid,
+): Promise<SoundscapeMusicTrackCandidate[]> {
+  const candidates: SoundscapeMusicTrackCandidate[] = [];
+
+  for (const playlistUuid of program.playlistUuids) {
+    const playlist = await getPlaylistByUuid(playlistUuid);
+    if (!playlist) continue;
+
+    const sounds = sortPlaylistSounds([...(playlist.sounds ?? [])])
+      .filter((sound) => typeof sound.path === "string" && sound.path.trim().length > 0);
+
+    for (const sound of sounds) {
+      candidates.push({
+        playlistId: playlist.id,
+        playlistUuid: playlist.uuid ?? playlistUuid,
+        playlistName: playlist.name?.trim() || "Untitled Playlist",
+        soundId: sound.id,
+        soundUuid: sound.uuid ?? null,
+        soundName: sound.name?.trim() || "Untitled Track",
+        sort: sound.sort ?? 0,
+        playlist,
+        sound,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+export class SoundscapeMusicRuntime {
+  private readonly deps: Required<RuntimeDeps>;
+  private readonly nextSequentialIndexByProgram = new Map<string, number>();
+  private readonly lastRandomIndexByProgram = new Map<string, number>();
+  private activeProgram: ActiveProgramContext | null = null;
+  private activeCandidate: SoundscapeMusicTrackCandidate | null = null;
+  private pendingTimer: unknown = null;
+  private pendingProgramKey: string | null = null;
+  private pendingDelayMs: number | null = null;
+  private lastError: string | null = null;
+
+  constructor(deps: RuntimeDeps = {}) {
+    this.deps = {
+      getPlaylistByUuid: deps.getPlaylistByUuid ?? defaultGetPlaylistByUuid,
+      timers: deps.timers ?? DEFAULT_TIMERS,
+      random: deps.random ?? Math.random,
+      now: deps.now ?? Date.now,
+    };
+  }
+
+  getSnapshot(): SoundscapeMusicRuntimeSnapshot {
+    return {
+      activeProgramKey: this.activeProgram?.key ?? null,
+      activeProgramId: this.activeProgram?.program.id ?? null,
+      activePlaylistUuid: this.activeCandidate?.playlistUuid ?? null,
+      activeSoundId: this.activeCandidate?.soundId ?? null,
+      pendingProgramKey: this.pendingProgramKey,
+      pendingDelayMs: this.pendingDelayMs,
+      lastError: this.lastError,
+    };
+  }
+
+  async sync(state: ResolvedSoundscapeState | null): Promise<SoundscapeMusicRuntimeSnapshot> {
+    const nextProgram = state?.musicProgram;
+    if (!state || !nextProgram || !state.musicProgramId) {
+      await this.stop();
+      return this.getSnapshot();
+    }
+
+    const nextKey = createProgramKey(state.profileId, state.musicProgramId);
+    if (this.activeProgram?.key !== nextKey) {
+      const stoppedCandidate = await this.stopActivePlayback();
+      this.clearPendingTimer();
+      this.activeProgram = {
+        key: nextKey,
+        program: nextProgram,
+        profileId: state.profileId,
+      };
+      await this.playNextCandidate(nextProgram, nextKey);
+      this.primeIgnoredStaleEndEvent(stoppedCandidate);
+      return this.getSnapshot();
+    }
+
+    if (!this.activeCandidate && !this.pendingTimer) {
+      await this.playNextCandidate(nextProgram, nextKey);
+    }
+
+    return this.getSnapshot();
+  }
+
+  handleTrackEnded(ref: SoundscapeEndedTrackRef): void {
+    if (!this.activeProgram || !this.activeCandidate) return;
+    if (ref.soundId !== this.activeCandidate.soundId) return;
+    if (ref.playlistUuid && ref.playlistUuid !== this.activeCandidate.playlistUuid) return;
+    if (ref.playlistId && ref.playlistId !== this.activeCandidate.playlistId) return;
+    if (this.shouldIgnoreEndedTrack(ref)) return;
+
+    const completedProgram = this.activeProgram;
+    const programDelayMs = Math.max(0, completedProgram.program.delaySeconds * 1000);
+
+    this.activeCandidate = null;
+    this.clearPendingTimer();
+
+    const scheduleNext = () => {
+      void this.playNextCandidate(completedProgram.program, completedProgram.key);
+    };
+
+    if (programDelayMs <= 0) {
+      scheduleNext();
+      return;
+    }
+
+    this.pendingProgramKey = completedProgram.key;
+    this.pendingDelayMs = programDelayMs;
+    this.pendingTimer = this.deps.timers.setTimeout(() => {
+      this.pendingTimer = null;
+      this.pendingProgramKey = null;
+      this.pendingDelayMs = null;
+      scheduleNext();
+    }, programDelayMs);
+  }
+
+  async stop(): Promise<void> {
+    await this.stopActivePlayback();
+    this.clearPendingTimer();
+    this.activeProgram = null;
+    this.ignoredEndedTrack = null;
+    this.lastError = null;
+  }
+
+  private ignoredEndedTrack: IgnoredEndedTrack | null = null;
+
+  private async stopActivePlayback(): Promise<CandidateIdentity | null> {
+    const activeCandidate = this.activeCandidate;
+    this.activeCandidate = null;
+
+    if (!activeCandidate) return null;
+    try {
+      if (activeCandidate.playlist.stopSound) {
+        await activeCandidate.playlist.stopSound(activeCandidate.sound);
+      } else {
+        await activeCandidate.playlist.stopAll?.();
+      }
+    } catch {
+      this.lastError = "Failed to stop active music track cleanly.";
+    }
+    return {
+      playlistId: activeCandidate.playlistId,
+      playlistUuid: activeCandidate.playlistUuid,
+      soundId: activeCandidate.soundId,
+    };
+  }
+
+  private clearPendingTimer(): void {
+    if (this.pendingTimer !== null) {
+      this.deps.timers.clearTimeout(this.pendingTimer);
+    }
+    this.pendingTimer = null;
+    this.pendingProgramKey = null;
+    this.pendingDelayMs = null;
+  }
+
+  private shouldIgnoreEndedTrack(ref: SoundscapeEndedTrackRef): boolean {
+    if (!this.ignoredEndedTrack) return false;
+
+    const activeCandidateKey = this.activeCandidate ? createCandidateKey(this.activeCandidate) : null;
+    if (activeCandidateKey !== this.ignoredEndedTrack.key) {
+      this.ignoredEndedTrack = null;
+      return false;
+    }
+
+    const refKey = createEndedTrackKey(ref);
+    if (refKey !== this.ignoredEndedTrack.key) return false;
+    if (this.deps.now() > this.ignoredEndedTrack.ignoreUntil) {
+      this.ignoredEndedTrack = null;
+      return false;
+    }
+
+    this.ignoredEndedTrack = null;
+    return true;
+  }
+
+  private primeIgnoredStaleEndEvent(stoppedCandidate: CandidateIdentity | null): void {
+    if (!stoppedCandidate || !this.activeCandidate) {
+      this.ignoredEndedTrack = null;
+      return;
+    }
+
+    const stoppedKey = createCandidateKey(stoppedCandidate);
+    const activeKey = createCandidateKey(this.activeCandidate);
+    if (stoppedKey !== activeKey) {
+      this.ignoredEndedTrack = null;
+      return;
+    }
+
+    // Ignore one immediate stop echo when a program switch restarts the same track.
+    this.ignoredEndedTrack = {
+      key: activeKey,
+      ignoreUntil: this.deps.now() + PROGRAM_SWITCH_STALE_END_GRACE_MS,
+    };
+  }
+
+  private pickCandidate(
+    programKey: string,
+    program: SoundscapeMusicProgram,
+    candidates: SoundscapeMusicTrackCandidate[],
+  ): SoundscapeMusicTrackCandidate {
+    if (program.selectionMode === "random") {
+      const lastIndex = this.lastRandomIndexByProgram.get(programKey) ?? -1;
+      const rawIndex = Math.floor(this.deps.random() * candidates.length);
+      const nextIndex = candidates.length > 1 && rawIndex === lastIndex
+        ? (rawIndex + 1) % candidates.length
+        : rawIndex;
+      this.lastRandomIndexByProgram.set(programKey, nextIndex);
+      return candidates[nextIndex]!;
+    }
+
+    const nextIndex = this.nextSequentialIndexByProgram.get(programKey) ?? 0;
+    const normalizedIndex = nextIndex % candidates.length;
+    this.nextSequentialIndexByProgram.set(programKey, normalizedIndex + 1);
+    return candidates[normalizedIndex]!;
+  }
+
+  private async playNextCandidate(program: SoundscapeMusicProgram, programKey: string): Promise<void> {
+    if (this.activeProgram?.key !== programKey) return;
+
+    const candidates = await resolveMusicTrackCandidates(program, this.deps.getPlaylistByUuid);
+    if (candidates.length === 0) {
+      this.lastError = `No valid playlist tracks could be resolved for music program "${program.name}".`;
+      this.activeCandidate = null;
+      return;
+    }
+
+    const candidate = this.pickCandidate(programKey, program, candidates);
+    this.lastError = null;
+
+    try {
+      await candidate.sound.load?.();
+      if (!candidate.playlist.playSound) {
+        this.lastError = `Playlist "${candidate.playlistName}" cannot start playback on this client.`;
+        this.activeCandidate = null;
+        return;
+      }
+      await candidate.playlist.playSound(candidate.sound);
+      candidate.sound.sync?.();
+      this.activeCandidate = candidate;
+    } catch {
+      this.lastError = `Failed to start track "${candidate.soundName}".`;
+      this.activeCandidate = null;
+    }
+  }
+}
+
+export const __soundscapeMusicRuntimeInternals = {
+  PROGRAM_SWITCH_STALE_END_GRACE_MS,
+  createProgramKey,
+  createCandidateKey,
+  createEndedTrackKey,
+  defaultGetPlaylistByUuid,
+  sortPlaylistSounds,
+};
+
+function createCandidateKey(candidate: CandidateIdentity): string {
+  return `${candidate.playlistUuid}:${candidate.playlistId}:${candidate.soundId}`;
+}
+
+function createEndedTrackKey(ref: SoundscapeEndedTrackRef): string | null {
+  if (!ref.playlistUuid || !ref.playlistId) return null;
+  return `${ref.playlistUuid}:${ref.playlistId}:${ref.soundId}`;
+}

--- a/src/types/foundry.d.ts
+++ b/src/types/foundry.d.ts
@@ -171,7 +171,21 @@ export interface FoundryScene extends FoundryDocument {
   active?: boolean;
 }
 
-export interface FoundryPlaylist extends FoundryDocument {}
+export interface FoundryPlaylistSound extends FoundryDocument {
+  path?: string;
+  playing?: boolean;
+  repeat?: boolean;
+  sort?: number;
+  load?(): Promise<void>;
+  sync?(): void;
+}
+
+export interface FoundryPlaylist extends FoundryDocument {
+  sounds?: FoundryCollection<FoundryPlaylistSound>;
+  playSound?(sound: FoundryPlaylistSound): Promise<FoundryPlaylist>;
+  stopSound?(sound: FoundryPlaylistSound): Promise<FoundryPlaylist>;
+  stopAll?(): Promise<FoundryPlaylist>;
+}
 
 /* ── Socket ───────────────────────────────────────────────── */
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export type {
   FoundrySettings,
   FoundryScene,
   FoundryPlaylist,
+  FoundryPlaylistSound,
   SettingRegistration,
   SettingMenuRegistration,
   FoundryCompendiumCollection,


### PR DESCRIPTION
## Summary
- add the reactive soundscapes adaptive music runtime and singleton controller
- expose music sync/stop/state through the soundscape debug API and extend local playlist typings
- cover music sequencing, random playback, cooldowns, switch races, and controller/API seams with tests

## Testing
- npm run typecheck
- npx vitest run src/soundscapes/soundscape-music-runtime.test.ts src/soundscapes/soundscape-music-controller.test.ts src/fth-api.test.ts
- npm run test
- npm run build

Closes #71
