### PR TITLE
Implement reactive soundscape ambience runtime

### DIFF
--- a/src/fth-api.test.ts
+++ b/src/fth-api.test.ts
@@ -19,6 +19,10 @@ const buildSoundscapeApiMock = vi.fn(() => ({
     syncMusic: vi.fn(async () => ({})),
     stopMusic: vi.fn(async () => {}),
     getMusicState: vi.fn(() => ({})),
+    syncAmbience: vi.fn(async () => ({})),
+    stopAmbience: vi.fn(async () => {}),
+    getAmbienceState: vi.fn(() => ({})),
+    playMoment: vi.fn(async () => ({})),
   },
 }));
 
@@ -83,6 +87,10 @@ describe("fth api", () => {
     await api.soundscapes.syncMusic();
     await api.soundscapes.stopMusic();
     api.soundscapes.getMusicState();
+    await api.soundscapes.syncAmbience();
+    await api.soundscapes.stopAmbience();
+    api.soundscapes.getAmbienceState();
+    await api.soundscapes.playMoment("sting");
 
     expect(setLevelMock).toHaveBeenCalledWith("debug");
     expect(openAssetManagerMock).toHaveBeenCalledTimes(1);

--- a/src/soundscapes/soundscape-ambience-controller.test.ts
+++ b/src/soundscapes/soundscape-ambience-controller.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveStoredSoundscapeStateMock = vi.fn();
+const runtimeSyncMock = vi.fn();
+const runtimeStopMock = vi.fn();
+const runtimeGetSnapshotMock = vi.fn(() => ({
+  activeAmbienceKey: null,
+  activeLayerIds: [],
+  loopSoundUuids: [],
+  randomLayerIds: [],
+  activeRandomSoundUuids: [],
+  pendingRandomLayerIds: [],
+  lastError: null,
+}));
+const runtimePlayMomentFromStateMock = vi.fn();
+
+vi.mock("./soundscape-accessors", () => ({
+  resolveStoredSoundscapeState: resolveStoredSoundscapeStateMock,
+}));
+
+vi.mock("./soundscape-ambience-runtime", () => ({
+  SoundscapeAmbienceRuntime: class {
+    sync = runtimeSyncMock;
+    stop = runtimeStopMock;
+    getSnapshot = runtimeGetSnapshotMock;
+    playMomentFromState = runtimePlayMomentFromStateMock;
+  },
+}));
+
+describe("soundscape ambience controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveStoredSoundscapeStateMock.mockReturnValue({
+      profileId: "forest",
+      ambienceLayerIds: ["wind"],
+      ambienceLayers: [{ id: "wind" }],
+      soundMoments: [{ id: "sting" }],
+    });
+    runtimeSyncMock.mockResolvedValue(runtimeGetSnapshotMock());
+    runtimeStopMock.mockResolvedValue(undefined);
+    runtimePlayMomentFromStateMock.mockResolvedValue({
+      momentId: "sting",
+      soundUuid: "PlaylistSound.sting",
+      played: true,
+      error: null,
+    });
+  });
+
+  it("resolves stored state and hands it to the singleton runtime", async () => {
+    const mod = await import("./soundscape-ambience-controller");
+
+    await mod.syncStoredSoundscapeAmbience("scene-1", { weather: "rain" });
+
+    expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", { weather: "rain" });
+    expect(runtimeSyncMock).toHaveBeenCalledWith(expect.objectContaining({
+      profileId: "forest",
+      ambienceLayerIds: ["wind"],
+    }));
+  });
+
+  it("plays moments from the cached active soundscape state", async () => {
+    const mod = await import("./soundscape-ambience-controller");
+
+    await mod.syncStoredSoundscapeAmbience("scene-1");
+    await mod.playStoredSoundscapeMoment("sting");
+
+    expect(runtimePlayMomentFromStateMock).toHaveBeenCalledWith(expect.objectContaining({
+      profileId: "forest",
+    }), "sting");
+  });
+
+  it("stops playback and exposes the runtime snapshot", async () => {
+    const mod = await import("./soundscape-ambience-controller");
+
+    await mod.stopStoredSoundscapeAmbience();
+
+    expect(runtimeStopMock).toHaveBeenCalledTimes(1);
+    expect(mod.getSoundscapeAmbienceRuntimeSnapshot()).toEqual(runtimeGetSnapshotMock.mock.results[0]?.value);
+  });
+});

--- a/src/soundscapes/soundscape-ambience-controller.ts
+++ b/src/soundscapes/soundscape-ambience-controller.ts
@@ -1,0 +1,78 @@
+import { resolveStoredSoundscapeState } from "./soundscape-accessors";
+import {
+  SoundscapeAmbienceRuntime,
+  type SoundscapeAmbienceRuntimeSnapshot,
+  type SoundscapeMomentPlaybackResult,
+} from "./soundscape-ambience-runtime";
+import type { ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
+
+class SoundscapeAmbienceController {
+  private readonly runtime: SoundscapeAmbienceRuntime;
+  private lastResolvedState: ResolvedSoundscapeState | null = null;
+
+  constructor(runtime = new SoundscapeAmbienceRuntime()) {
+    this.runtime = runtime;
+  }
+
+  async syncResolvedState(state: ResolvedSoundscapeState | null): Promise<SoundscapeAmbienceRuntimeSnapshot> {
+    this.lastResolvedState = state;
+    return await this.runtime.sync(state);
+  }
+
+  async syncStoredState(
+    sceneId?: string,
+    context?: Partial<SoundscapeTriggerContext>,
+  ): Promise<SoundscapeAmbienceRuntimeSnapshot> {
+    return await this.syncResolvedState(resolveStoredSoundscapeState(sceneId, context));
+  }
+
+  async stop(): Promise<void> {
+    this.lastResolvedState = null;
+    await this.runtime.stop();
+  }
+
+  getSnapshot(): SoundscapeAmbienceRuntimeSnapshot {
+    return this.runtime.getSnapshot();
+  }
+
+  async playMoment(
+    momentId: string,
+    sceneId?: string,
+    context?: Partial<SoundscapeTriggerContext>,
+  ): Promise<SoundscapeMomentPlaybackResult> {
+    const nextState = sceneId !== undefined || context !== undefined
+      ? resolveStoredSoundscapeState(sceneId, context)
+      : (this.lastResolvedState ?? resolveStoredSoundscapeState());
+    this.lastResolvedState = nextState;
+    return await this.runtime.playMomentFromState(nextState, momentId);
+  }
+}
+
+const singletonController = new SoundscapeAmbienceController();
+
+export async function syncStoredSoundscapeAmbience(
+  sceneId?: string,
+  context?: Partial<SoundscapeTriggerContext>,
+): Promise<SoundscapeAmbienceRuntimeSnapshot> {
+  return await singletonController.syncStoredState(sceneId, context);
+}
+
+export async function stopStoredSoundscapeAmbience(): Promise<void> {
+  await singletonController.stop();
+}
+
+export function getSoundscapeAmbienceRuntimeSnapshot(): SoundscapeAmbienceRuntimeSnapshot {
+  return singletonController.getSnapshot();
+}
+
+export async function playStoredSoundscapeMoment(
+  momentId: string,
+  sceneId?: string,
+  context?: Partial<SoundscapeTriggerContext>,
+): Promise<SoundscapeMomentPlaybackResult> {
+  return await singletonController.playMoment(momentId, sceneId, context);
+}
+
+export const __soundscapeAmbienceControllerInternals = {
+  singletonController,
+};

--- a/src/soundscapes/soundscape-ambience-runtime.test.ts
+++ b/src/soundscapes/soundscape-ambience-runtime.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { SoundscapeAmbienceRuntime } from "./soundscape-ambience-runtime";
+import type { ResolvedSoundscapeState, SoundscapeAmbienceLayer, SoundscapeSoundMoment } from "./soundscape-types";
+
+interface FakeTimerHandle {
+  callback: () => void;
+  delay: number;
+  cleared: boolean;
+}
+
+interface FakeSound {
+  duration?: number;
+  playing?: boolean;
+  play: (options?: Record<string, unknown>) => Promise<unknown>;
+  stop: () => Promise<unknown>;
+}
+
+interface FakeSoundDocument {
+  id: string;
+  uuid: string;
+  name: string;
+  path: string;
+  sound: FakeSound;
+  load: () => Promise<void>;
+  sync: () => void;
+}
+
+function createFakeTimers() {
+  const handles: FakeTimerHandle[] = [];
+  return {
+    handles,
+    api: {
+      setTimeout(callback: () => void, delay: number) {
+        const handle = { callback, delay, cleared: false };
+        handles.push(handle);
+        return handle;
+      },
+      clearTimeout(handle: unknown) {
+        const timer = handle as FakeTimerHandle | undefined;
+        if (timer) timer.cleared = true;
+      },
+    },
+    runNext() {
+      const handle = handles.find((entry) => !entry.cleared);
+      if (!handle) return;
+      handle.cleared = true;
+      handle.callback();
+    },
+  };
+}
+
+function createSoundDocument(uuid: string, durationSeconds = 1): FakeSoundDocument {
+  const play = vi.fn(async (_options?: Record<string, unknown>): Promise<void> => {});
+  const stop = vi.fn(async (): Promise<void> => {});
+  const load = vi.fn(async (): Promise<void> => {});
+  const sync = vi.fn((): void => {});
+
+  return {
+    id: uuid.split(".").at(-1) ?? uuid,
+    uuid,
+    name: uuid,
+    path: `sounds/${uuid}.ogg`,
+    sound: {
+      duration: durationSeconds,
+      play,
+      stop,
+    },
+    load,
+    sync,
+  };
+}
+
+function createResolvedState(options: {
+  profileId?: string;
+  ambienceLayers?: SoundscapeAmbienceLayer[];
+  soundMoments?: SoundscapeSoundMoment[];
+} = {}): ResolvedSoundscapeState {
+  return {
+    profileId: options.profileId ?? "forest",
+    assignmentSource: "worldDefault",
+    sceneId: "scene-1",
+    context: {
+      manualPreview: false,
+      inCombat: false,
+      weather: null,
+      timeOfDay: null,
+    },
+    musicProgramId: null,
+    musicProgram: null,
+    musicRuleId: null,
+    ambienceLayerIds: (options.ambienceLayers ?? []).map((layer) => layer.id),
+    ambienceLayers: options.ambienceLayers ?? [],
+    ambienceRuleId: "base",
+    soundMoments: options.soundMoments ?? [],
+  };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("soundscape ambience runtime", () => {
+  it("starts loop layers and prevents duplicate ambience playback for shared sources", async () => {
+    const wind = createSoundDocument("PlaylistSound.wind");
+    const birds = createSoundDocument("PlaylistSound.birds");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async (uuid) => {
+        if (uuid === "PlaylistSound.wind") return wind;
+        if (uuid === "PlaylistSound.birds") return birds;
+        return null;
+      },
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [
+        {
+          id: "forest-loop",
+          name: "Forest Loop",
+          mode: "loop",
+          soundUuids: ["PlaylistSound.wind", "PlaylistSound.birds"],
+          minDelaySeconds: 0,
+          maxDelaySeconds: 0,
+        },
+        {
+          id: "mist-loop",
+          name: "Mist Loop",
+          mode: "loop",
+          soundUuids: ["PlaylistSound.wind"],
+          minDelaySeconds: 0,
+          maxDelaySeconds: 0,
+        },
+      ],
+    }));
+
+    expect(wind.sound.play).toHaveBeenCalledTimes(1);
+    expect(birds.sound.play).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeLayerIds: ["forest-loop", "mist-loop"],
+      loopSoundUuids: ["PlaylistSound.birds", "PlaylistSound.wind"],
+      randomLayerIds: [],
+    });
+  });
+
+  it("restarts a shared loop for the remaining layer when the original owner is removed", async () => {
+    const wind = createSoundDocument("PlaylistSound.wind");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => wind,
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [
+        {
+          id: "forest-loop",
+          name: "Forest Loop",
+          mode: "loop",
+          soundUuids: ["PlaylistSound.wind"],
+          minDelaySeconds: 0,
+          maxDelaySeconds: 0,
+        },
+        {
+          id: "mist-loop",
+          name: "Mist Loop",
+          mode: "loop",
+          soundUuids: ["PlaylistSound.wind"],
+          minDelaySeconds: 0,
+          maxDelaySeconds: 0,
+        },
+      ],
+    }));
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [
+        {
+          id: "mist-loop",
+          name: "Mist Loop",
+          mode: "loop",
+          soundUuids: ["PlaylistSound.wind"],
+          minDelaySeconds: 0,
+          maxDelaySeconds: 0,
+        },
+      ],
+    }));
+
+    expect(wind.sound.play).toHaveBeenCalledTimes(2);
+    expect(wind.sound.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeLayerIds: ["mist-loop"],
+      loopSoundUuids: ["PlaylistSound.wind"],
+    });
+  });
+
+  it("schedules random ambience layers and avoids immediate repeats when alternatives exist", async () => {
+    const timers = createFakeTimers();
+    const gustA = createSoundDocument("PlaylistSound.gust-a", 2);
+    const gustB = createSoundDocument("PlaylistSound.gust-b", 2);
+    const randomValues = [0, 0, 0];
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async (uuid) => {
+        if (uuid === "PlaylistSound.gust-a") return gustA;
+        if (uuid === "PlaylistSound.gust-b") return gustB;
+        return null;
+      },
+      timers: timers.api,
+      random: () => randomValues.shift() ?? 0,
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [{
+        id: "winds",
+        name: "Winds",
+        mode: "random",
+        soundUuids: ["PlaylistSound.gust-a", "PlaylistSound.gust-b"],
+        minDelaySeconds: 1,
+        maxDelaySeconds: 3,
+      }],
+    }));
+
+    expect(timers.handles[0]?.delay).toBe(1000);
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    expect(gustA.sound.play).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeRandomSoundUuids: ["PlaylistSound.gust-a"],
+      pendingRandomLayerIds: [],
+    });
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    expect(timers.handles.find((handle) => !handle.cleared)?.delay).toBe(1000);
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    expect(gustB.sound.play).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeRandomSoundUuids: ["PlaylistSound.gust-b"],
+    });
+  });
+
+  it("cleans up obsolete loops, active random playback, and timers when ambience changes", async () => {
+    const timers = createFakeTimers();
+    const rain = createSoundDocument("PlaylistSound.rain", 10);
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => rain,
+      timers: timers.api,
+      random: () => 0,
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [{
+        id: "rain-loop",
+        name: "Rain Loop",
+        mode: "loop",
+        soundUuids: ["PlaylistSound.rain"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }, {
+        id: "rain-hits",
+        name: "Rain Hits",
+        mode: "random",
+        soundUuids: ["PlaylistSound.rain"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+    }));
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [],
+    }));
+
+    expect(rain.sound.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeAmbienceKey: null,
+      activeLayerIds: [],
+      loopSoundUuids: [],
+      pendingRandomLayerIds: [],
+    });
+    expect(timers.handles.every((handle) => handle.cleared)).toBe(true);
+  });
+
+  it("plays manual sound moments on demand without mutating ambience state", async () => {
+    const sting = createSoundDocument("PlaylistSound.sting");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => sting,
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [{
+        id: "forest-loop",
+        name: "Forest Loop",
+        mode: "loop",
+        soundUuids: ["PlaylistSound.sting"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+      soundMoments: [{
+        id: "sting",
+        name: "Sting",
+        soundUuids: ["PlaylistSound.sting"],
+        selectionMode: "single",
+      }],
+    }));
+
+    const before = runtime.getSnapshot();
+    const result = await runtime.playMomentFromState(createResolvedState({
+      soundMoments: [{
+        id: "sting",
+        name: "Sting",
+        soundUuids: ["PlaylistSound.sting"],
+        selectionMode: "single",
+      }],
+    }), "sting");
+
+    expect(result).toEqual({
+      momentId: "sting",
+      soundUuid: "PlaylistSound.sting",
+      played: true,
+      error: null,
+    });
+    expect(sting.sound.play).toHaveBeenCalledTimes(2);
+    expect(runtime.getSnapshot()).toEqual(before);
+  });
+
+  it("does not start a loop after its layer is removed while sound resolution is still pending", async () => {
+    const deferred = createDeferred<FakeSoundDocument | null>();
+    const wind = createSoundDocument("PlaylistSound.wind");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => await deferred.promise,
+    });
+
+    const startingSync = runtime.sync(createResolvedState({
+      ambienceLayers: [{
+        id: "forest-loop",
+        name: "Forest Loop",
+        mode: "loop",
+        soundUuids: ["PlaylistSound.wind"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+    }));
+    await flushAsyncWork();
+
+    const stoppingSync = runtime.sync(createResolvedState({ ambienceLayers: [] }));
+    deferred.resolve(wind);
+
+    await startingSync;
+    await stoppingSync;
+
+    expect(wind.sound.play).not.toHaveBeenCalled();
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeLayerIds: [],
+      loopSoundUuids: [],
+    });
+  });
+
+  it("does not start random ambience after its layer is removed while sound resolution is still pending", async () => {
+    const timers = createFakeTimers();
+    const deferred = createDeferred<FakeSoundDocument | null>();
+    const rain = createSoundDocument("PlaylistSound.rain");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => await deferred.promise,
+      timers: timers.api,
+      random: () => 0,
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [{
+        id: "rain-hits",
+        name: "Rain Hits",
+        mode: "random",
+        soundUuids: ["PlaylistSound.rain"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+    }));
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    const stoppingSync = runtime.sync(createResolvedState({ ambienceLayers: [] }));
+    deferred.resolve(rain);
+
+    await stoppingSync;
+    await flushAsyncWork();
+
+    expect(rain.sound.play).not.toHaveBeenCalled();
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeLayerIds: [],
+      activeRandomSoundUuids: [],
+      pendingRandomLayerIds: [],
+    });
+  });
+
+  it("does not double-start the same loop when sync is called again during pending startup", async () => {
+    const deferred = createDeferred<FakeSoundDocument | null>();
+    const wind = createSoundDocument("PlaylistSound.wind");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => await deferred.promise,
+    });
+    const state = createResolvedState({
+      ambienceLayers: [{
+        id: "forest-loop",
+        name: "Forest Loop",
+        mode: "loop",
+        soundUuids: ["PlaylistSound.wind"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+    });
+
+    const firstSync = runtime.sync(state);
+    await flushAsyncWork();
+    const secondSync = runtime.sync(state);
+    deferred.resolve(wind);
+
+    await firstSync;
+    await secondSync;
+
+    expect(wind.sound.play).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeLayerIds: ["forest-loop"],
+      loopSoundUuids: ["PlaylistSound.wind"],
+    });
+  });
+
+  it("does not reschedule the same random layer while startup is already pending", async () => {
+    const timers = createFakeTimers();
+    const deferred = createDeferred<FakeSoundDocument | null>();
+    const rain = createSoundDocument("PlaylistSound.rain");
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveSoundByUuid: async () => await deferred.promise,
+      timers: timers.api,
+      random: () => 0,
+    });
+    const state = createResolvedState({
+      ambienceLayers: [{
+        id: "rain-hits",
+        name: "Rain Hits",
+        mode: "random",
+        soundUuids: ["PlaylistSound.rain"],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+    });
+
+    await runtime.sync(state);
+    timers.runNext();
+    await flushAsyncWork();
+
+    await runtime.sync(state);
+
+    deferred.resolve(rain);
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(rain.sound.play).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeLayerIds: ["rain-hits"],
+      activeRandomSoundUuids: ["PlaylistSound.rain"],
+      pendingRandomLayerIds: [],
+    });
+  });
+});

--- a/src/soundscapes/soundscape-ambience-runtime.ts
+++ b/src/soundscapes/soundscape-ambience-runtime.ts
@@ -1,0 +1,564 @@
+import { fromUuid } from "../types";
+import type {
+  ResolvedSoundscapeState,
+  SoundscapeAmbienceLayer,
+  SoundscapeSoundMoment,
+} from "./soundscape-types";
+
+interface TimerApi {
+  setTimeout(callback: () => void, delay: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+interface RuntimeDeps {
+  resolveSoundByUuid?: (uuid: string) => Promise<RuntimeSoundDocumentLike | null>;
+  timers?: TimerApi;
+  random?: () => number;
+}
+
+interface RuntimeSoundLike {
+  duration?: number;
+  playing?: boolean;
+  play?: (options?: Record<string, unknown>) => Promise<unknown>;
+  stop?: () => Promise<unknown> | void;
+}
+
+interface RuntimeSoundDocumentLike {
+  id: string;
+  uuid?: string;
+  name?: string;
+  path?: string;
+  sound?: RuntimeSoundLike | null;
+  load?: () => Promise<void>;
+  sync?: () => void;
+}
+
+interface ActiveLoopSound {
+  soundUuid: string;
+  doc: RuntimeSoundDocumentLike;
+}
+
+interface ActiveRandomSound {
+  soundUuid: string;
+  doc: RuntimeSoundDocumentLike;
+  cleanupTimer: unknown | null;
+}
+
+interface LoopLayerRuntimeState {
+  type: "loop";
+  layer: SoundscapeAmbienceLayer;
+  fingerprint: string;
+  generation: number;
+  loopSounds: Map<string, ActiveLoopSound>;
+  pendingSoundUuids: Set<string>;
+}
+
+interface RandomLayerRuntimeState {
+  type: "random";
+  layer: SoundscapeAmbienceLayer;
+  fingerprint: string;
+  scheduleTimer: unknown | null;
+  activeSound: ActiveRandomSound | null;
+  lastPlayedSoundUuid: string | null;
+  pendingStartSoundUuid: string | null;
+  generation: number;
+}
+
+type ActiveLayerRuntimeState = LoopLayerRuntimeState | RandomLayerRuntimeState;
+
+const DEFAULT_TIMERS: TimerApi = {
+  setTimeout: (callback, delay) => globalThis.setTimeout(callback, delay),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export interface SoundscapeAmbienceRuntimeSnapshot {
+  activeAmbienceKey: string | null;
+  activeLayerIds: string[];
+  loopSoundUuids: string[];
+  randomLayerIds: string[];
+  activeRandomSoundUuids: string[];
+  pendingRandomLayerIds: string[];
+  lastError: string | null;
+}
+
+export interface SoundscapeMomentPlaybackResult {
+  momentId: string;
+  soundUuid: string | null;
+  played: boolean;
+  error: string | null;
+}
+
+function createAmbienceKey(profileId: string, layerIds: string[]): string {
+  return `${profileId}:${[...layerIds].sort().join("|")}`;
+}
+
+function createLayerFingerprint(layer: SoundscapeAmbienceLayer): string {
+  return [
+    layer.mode,
+    layer.minDelaySeconds,
+    layer.maxDelaySeconds,
+    ...layer.soundUuids,
+  ].join("|");
+}
+
+function randomDelayMs(layer: SoundscapeAmbienceLayer, random: () => number): number {
+  const minMs = Math.max(0, layer.minDelaySeconds * 1000);
+  const maxMs = Math.max(minMs, layer.maxDelaySeconds * 1000);
+  if (maxMs <= minMs) return minMs;
+  return Math.round(minMs + ((maxMs - minMs) * random()));
+}
+
+async function defaultResolveSoundByUuid(uuid: string): Promise<RuntimeSoundDocumentLike | null> {
+  const resolved = await fromUuid(uuid);
+  if (!resolved || typeof resolved.id !== "string") return null;
+  return resolved as RuntimeSoundDocumentLike;
+}
+
+function pickRandomIndex(random: () => number, length: number, lastIndex: number): number {
+  const rawIndex = Math.floor(random() * length);
+  if (length > 1 && rawIndex === lastIndex) return (rawIndex + 1) % length;
+  return rawIndex;
+}
+
+export class SoundscapeAmbienceRuntime {
+  private readonly deps: Required<RuntimeDeps>;
+  private readonly activeLayers = new Map<string, ActiveLayerRuntimeState>();
+  private readonly activeAmbienceOwners = new Map<string, string>();
+  private readonly lastRandomMomentIndexByMoment = new Map<string, number>();
+  private activeAmbienceKey: string | null = null;
+  private lastError: string | null = null;
+
+  constructor(deps: RuntimeDeps = {}) {
+    this.deps = {
+      resolveSoundByUuid: deps.resolveSoundByUuid ?? defaultResolveSoundByUuid,
+      timers: deps.timers ?? DEFAULT_TIMERS,
+      random: deps.random ?? Math.random,
+    };
+  }
+
+  getSnapshot(): SoundscapeAmbienceRuntimeSnapshot {
+    const activeLayerIds = [...this.activeLayers.keys()].sort();
+    const loopSoundUuids = [...this.activeAmbienceOwners.entries()]
+      .filter(([soundUuid, layerId]) => {
+        void soundUuid;
+        const state = this.activeLayers.get(layerId);
+        return state?.type === "loop";
+      })
+      .map(([soundUuid]) => soundUuid)
+      .sort();
+    const randomLayerIds = [...this.activeLayers.values()]
+      .filter((state): state is RandomLayerRuntimeState => state.type === "random")
+      .map((state) => state.layer.id)
+      .sort();
+    const activeRandomSoundUuids = [...this.activeLayers.values()]
+      .filter((state): state is RandomLayerRuntimeState => state.type === "random")
+      .flatMap((state) => state.activeSound ? [state.activeSound.soundUuid] : [])
+      .sort();
+    const pendingRandomLayerIds = [...this.activeLayers.values()]
+      .filter((state): state is RandomLayerRuntimeState => state.type === "random")
+      .flatMap((state) => state.scheduleTimer ? [state.layer.id] : [])
+      .sort();
+
+    return {
+      activeAmbienceKey: this.activeAmbienceKey,
+      activeLayerIds,
+      loopSoundUuids,
+      randomLayerIds,
+      activeRandomSoundUuids,
+      pendingRandomLayerIds,
+      lastError: this.lastError,
+    };
+  }
+
+  async sync(state: ResolvedSoundscapeState | null): Promise<SoundscapeAmbienceRuntimeSnapshot> {
+    const nextLayers = state?.ambienceLayers ?? [];
+    if (!state || nextLayers.length === 0) {
+      await this.stop();
+      return this.getSnapshot();
+    }
+
+    const nextLayerIds = new Set(nextLayers.map((layer) => layer.id));
+    for (const [layerId, activeState] of [...this.activeLayers.entries()]) {
+      const nextLayer = nextLayers.find((layer) => layer.id === layerId);
+      if (!nextLayer || createLayerFingerprint(nextLayer) !== activeState.fingerprint) {
+        await this.teardownLayer(layerId, activeState);
+      }
+    }
+
+    for (const layer of nextLayers) {
+      const activeState = this.activeLayers.get(layer.id);
+      if (!activeState && layer.mode === "loop") {
+        const loopState: LoopLayerRuntimeState = {
+          type: "loop",
+          layer,
+          fingerprint: createLayerFingerprint(layer),
+          generation: 0,
+          loopSounds: new Map(),
+          pendingSoundUuids: new Set(),
+        };
+        this.activeLayers.set(layer.id, loopState);
+      } else if (!activeState) {
+        const randomState: RandomLayerRuntimeState = {
+          type: "random",
+          layer,
+          fingerprint: createLayerFingerprint(layer),
+          scheduleTimer: null,
+          activeSound: null,
+          lastPlayedSoundUuid: null,
+          pendingStartSoundUuid: null,
+          generation: 0,
+        };
+        this.activeLayers.set(layer.id, randomState);
+      }
+
+      const nextState = this.activeLayers.get(layer.id);
+      if (!nextState) continue;
+      if (nextState.type === "loop") {
+        await this.startLoopLayer(nextState);
+      } else {
+        nextState.layer = layer;
+        nextState.fingerprint = createLayerFingerprint(layer);
+        this.scheduleRandomLayer(nextState);
+      }
+    }
+
+    for (const layerId of [...this.activeLayers.keys()]) {
+      if (!nextLayerIds.has(layerId)) {
+        const activeState = this.activeLayers.get(layerId);
+        if (activeState) await this.teardownLayer(layerId, activeState);
+      }
+    }
+
+    this.activeAmbienceKey = createAmbienceKey(state.profileId, nextLayers.map((layer) => layer.id));
+    return this.getSnapshot();
+  }
+
+  async stop(): Promise<void> {
+    for (const [layerId, activeState] of [...this.activeLayers.entries()]) {
+      await this.teardownLayer(layerId, activeState);
+    }
+    this.activeAmbienceKey = null;
+    this.lastError = null;
+  }
+
+  async playMoment(moment: SoundscapeSoundMoment | null | undefined): Promise<SoundscapeMomentPlaybackResult> {
+    if (!moment) {
+      return {
+        momentId: "",
+        soundUuid: null,
+        played: false,
+        error: "No sound moment is available to play.",
+      };
+    }
+
+    const selected = this.selectMomentSoundUuid(moment);
+    if (!selected) {
+      return {
+        momentId: moment.id,
+        soundUuid: null,
+        played: false,
+        error: `Sound moment "${moment.name}" has no playable sounds.`,
+      };
+    }
+
+    const doc = await this.deps.resolveSoundByUuid(selected);
+    if (!doc) {
+      return {
+        momentId: moment.id,
+        soundUuid: selected,
+        played: false,
+        error: `Sound moment "${moment.name}" could not resolve audio document "${selected}".`,
+      };
+    }
+
+    const started = await this.startSoundPlayback(doc, false);
+    if (!started) {
+      return {
+        momentId: moment.id,
+        soundUuid: selected,
+        played: false,
+        error: `Sound moment "${moment.name}" could not start playback.`,
+      };
+    }
+
+    return {
+      momentId: moment.id,
+      soundUuid: selected,
+      played: true,
+      error: null,
+    };
+  }
+
+  async playMomentFromState(
+    state: ResolvedSoundscapeState | null,
+    momentId: string,
+  ): Promise<SoundscapeMomentPlaybackResult> {
+    if (!state) {
+      return {
+        momentId,
+        soundUuid: null,
+        played: false,
+        error: "No active soundscape state is available.",
+      };
+    }
+
+    const moment = state.soundMoments.find((entry) => entry.id === momentId);
+    if (!moment) {
+      return {
+        momentId,
+        soundUuid: null,
+        played: false,
+        error: `Sound moment "${momentId}" is not available in the active soundscape.`,
+      };
+    }
+
+    return await this.playMoment(moment);
+  }
+
+  private async startLoopLayer(state: LoopLayerRuntimeState): Promise<void> {
+    const generation = state.generation;
+    for (const soundUuid of state.layer.soundUuids) {
+      if (state.loopSounds.has(soundUuid) || state.pendingSoundUuids.has(soundUuid)) continue;
+
+      state.pendingSoundUuids.add(soundUuid);
+      if (!this.claimAmbienceOwner(soundUuid, state.layer.id)) {
+        state.pendingSoundUuids.delete(soundUuid);
+        continue;
+      }
+
+      const doc = await this.deps.resolveSoundByUuid(soundUuid);
+      if (!doc) {
+        this.releaseAmbienceOwner(soundUuid, state.layer.id);
+        state.pendingSoundUuids.delete(soundUuid);
+        this.lastError = `Ambience layer "${state.layer.name}" could not resolve audio document "${soundUuid}".`;
+        continue;
+      }
+
+      if (!this.isCurrentLoopLayer(state.layer.id, generation) || this.activeAmbienceOwners.get(soundUuid) !== state.layer.id) {
+        this.releaseAmbienceOwner(soundUuid, state.layer.id);
+        state.pendingSoundUuids.delete(soundUuid);
+        continue;
+      }
+
+      const started = await this.startSoundPlayback(doc, true);
+      if (!started || !this.isCurrentLoopLayer(state.layer.id, generation) || this.activeAmbienceOwners.get(soundUuid) !== state.layer.id) {
+        this.releaseAmbienceOwner(soundUuid, state.layer.id);
+        state.pendingSoundUuids.delete(soundUuid);
+        if (started) await this.stopSoundPlayback(doc);
+        this.lastError = `Ambience layer "${state.layer.name}" could not start loop "${soundUuid}".`;
+        continue;
+      }
+
+      const currentState = this.activeLayers.get(state.layer.id);
+      if (!currentState || currentState.type !== "loop" || currentState.generation !== generation) {
+        this.releaseAmbienceOwner(soundUuid, state.layer.id);
+        state.pendingSoundUuids.delete(soundUuid);
+        await this.stopSoundPlayback(doc);
+        continue;
+      }
+
+      currentState.loopSounds.set(soundUuid, { soundUuid, doc });
+      currentState.pendingSoundUuids.delete(soundUuid);
+    }
+  }
+
+  private scheduleRandomLayer(state: RandomLayerRuntimeState, explicitDelayMs?: number): void {
+    if (state.scheduleTimer || state.activeSound || state.pendingStartSoundUuid || !this.activeLayers.has(state.layer.id)) return;
+
+    const delayMs = explicitDelayMs ?? randomDelayMs(state.layer, this.deps.random);
+    const generation = state.generation;
+    state.scheduleTimer = this.deps.timers.setTimeout(() => {
+      state.scheduleTimer = null;
+      void this.handleRandomLayerTimer(state.layer.id, generation);
+    }, delayMs);
+  }
+
+  private async handleRandomLayerTimer(layerId: string, generation: number): Promise<void> {
+    const state = this.activeLayers.get(layerId);
+    if (!state || state.type !== "random" || state.generation !== generation || state.activeSound) return;
+
+    const selectedSoundUuid = this.selectRandomLayerSoundUuid(state);
+    if (!selectedSoundUuid) {
+      this.scheduleRandomLayer(state, Math.max(0, state.layer.minDelaySeconds * 1000));
+      return;
+    }
+    if (!this.claimAmbienceOwner(selectedSoundUuid, state.layer.id)) {
+      this.scheduleRandomLayer(state, Math.max(0, state.layer.minDelaySeconds * 1000));
+      return;
+    }
+    state.pendingStartSoundUuid = selectedSoundUuid;
+
+    const doc = await this.deps.resolveSoundByUuid(selectedSoundUuid);
+    if (!doc) {
+      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
+      state.pendingStartSoundUuid = null;
+      this.lastError = `Ambience layer "${state.layer.name}" could not resolve audio document "${selectedSoundUuid}".`;
+      this.scheduleRandomLayer(state);
+      return;
+    }
+
+    if (!this.isCurrentRandomLayer(layerId, generation) || this.activeAmbienceOwners.get(selectedSoundUuid) !== state.layer.id) {
+      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
+      state.pendingStartSoundUuid = null;
+      return;
+    }
+
+    const started = await this.startSoundPlayback(doc, false);
+    if (!started || !this.isCurrentRandomLayer(layerId, generation) || this.activeAmbienceOwners.get(selectedSoundUuid) !== state.layer.id) {
+      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
+      state.pendingStartSoundUuid = null;
+      if (started) await this.stopSoundPlayback(doc);
+      this.lastError = `Ambience layer "${state.layer.name}" could not start "${selectedSoundUuid}".`;
+      const currentState = this.activeLayers.get(layerId);
+      if (currentState && currentState.type === "random" && currentState.generation === generation) {
+        this.scheduleRandomLayer(currentState);
+      }
+      return;
+    }
+
+    const currentState = this.activeLayers.get(layerId);
+    if (!currentState || currentState.type !== "random" || currentState.generation !== generation) {
+      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
+      state.pendingStartSoundUuid = null;
+      await this.stopSoundPlayback(doc);
+      return;
+    }
+
+    currentState.lastPlayedSoundUuid = selectedSoundUuid;
+    currentState.pendingStartSoundUuid = null;
+
+    const durationMs = Math.max(0, Math.round((doc.sound?.duration ?? 0) * 1000));
+    const cleanupTimer = this.deps.timers.setTimeout(() => {
+      void this.finishRandomLayerSound(layerId, generation, selectedSoundUuid);
+    }, durationMs);
+
+    currentState.activeSound = {
+      soundUuid: selectedSoundUuid,
+      doc,
+      cleanupTimer,
+    };
+  }
+
+  private async finishRandomLayerSound(layerId: string, generation: number, soundUuid: string): Promise<void> {
+    const state = this.activeLayers.get(layerId);
+    if (!state || state.type !== "random" || state.generation !== generation) return;
+    if (!state.activeSound || state.activeSound.soundUuid !== soundUuid) return;
+
+    if (state.activeSound.cleanupTimer !== null) {
+      this.deps.timers.clearTimeout(state.activeSound.cleanupTimer);
+    }
+
+    this.activeAmbienceOwners.delete(soundUuid);
+    state.activeSound = null;
+    this.scheduleRandomLayer(state);
+  }
+
+  private selectRandomLayerSoundUuid(state: RandomLayerRuntimeState): string | null {
+    const candidates = state.layer.soundUuids.filter((soundUuid) => !this.activeAmbienceOwners.has(soundUuid));
+    if (candidates.length === 0) return null;
+
+    const lastIndex = state.lastPlayedSoundUuid ? candidates.indexOf(state.lastPlayedSoundUuid) : -1;
+    return candidates[pickRandomIndex(this.deps.random, candidates.length, lastIndex)] ?? null;
+  }
+
+  private selectMomentSoundUuid(moment: SoundscapeSoundMoment): string | null {
+    if (moment.soundUuids.length === 0) return null;
+    if (moment.selectionMode === "single") return moment.soundUuids[0] ?? null;
+
+    const lastIndex = this.lastRandomMomentIndexByMoment.get(moment.id) ?? -1;
+    const nextIndex = pickRandomIndex(this.deps.random, moment.soundUuids.length, lastIndex);
+    this.lastRandomMomentIndexByMoment.set(moment.id, nextIndex);
+    return moment.soundUuids[nextIndex] ?? null;
+  }
+
+  private async startSoundPlayback(doc: RuntimeSoundDocumentLike, loop: boolean): Promise<boolean> {
+    try {
+      await doc.load?.();
+      if (!doc.sound?.play) return false;
+      await doc.sound.play({ loop });
+      doc.sync?.();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async stopSoundPlayback(doc: RuntimeSoundDocumentLike | null | undefined): Promise<void> {
+    if (!doc?.sound?.stop) return;
+    try {
+      await doc.sound.stop();
+    } catch {
+      this.lastError = "Failed to stop ambience playback cleanly.";
+    }
+  }
+
+  private async teardownLayer(layerId: string, state: ActiveLayerRuntimeState): Promise<void> {
+    if (state.type === "loop") {
+      state.generation += 1;
+      this.releaseAmbienceOwnersForLayer(layerId);
+      state.pendingSoundUuids.clear();
+      for (const [, activeSound] of state.loopSounds.entries()) {
+        await this.stopSoundPlayback(activeSound.doc);
+      }
+      state.loopSounds.clear();
+    } else {
+      state.generation += 1;
+      this.releaseAmbienceOwnersForLayer(layerId);
+      state.pendingStartSoundUuid = null;
+      if (state.scheduleTimer !== null) {
+        this.deps.timers.clearTimeout(state.scheduleTimer);
+        state.scheduleTimer = null;
+      }
+      if (state.activeSound) {
+        if (state.activeSound.cleanupTimer !== null) {
+          this.deps.timers.clearTimeout(state.activeSound.cleanupTimer);
+        }
+        await this.stopSoundPlayback(state.activeSound.doc);
+      }
+      state.activeSound = null;
+    }
+
+    this.activeLayers.delete(layerId);
+    if (this.activeLayers.size === 0) {
+      this.activeAmbienceKey = null;
+    }
+  }
+
+  private claimAmbienceOwner(soundUuid: string, layerId: string): boolean {
+    const currentOwner = this.activeAmbienceOwners.get(soundUuid);
+    if (currentOwner && currentOwner !== layerId) return false;
+    this.activeAmbienceOwners.set(soundUuid, layerId);
+    return true;
+  }
+
+  private releaseAmbienceOwner(soundUuid: string, layerId: string): void {
+    if (this.activeAmbienceOwners.get(soundUuid) === layerId) {
+      this.activeAmbienceOwners.delete(soundUuid);
+    }
+  }
+
+  private releaseAmbienceOwnersForLayer(layerId: string): void {
+    for (const [soundUuid, ownerLayerId] of [...this.activeAmbienceOwners.entries()]) {
+      if (ownerLayerId === layerId) {
+        this.activeAmbienceOwners.delete(soundUuid);
+      }
+    }
+  }
+
+  private isCurrentLoopLayer(layerId: string, generation: number): boolean {
+    const currentState = this.activeLayers.get(layerId);
+    return !!currentState && currentState.type === "loop" && currentState.generation === generation;
+  }
+
+  private isCurrentRandomLayer(layerId: string, generation: number): boolean {
+    const currentState = this.activeLayers.get(layerId);
+    return !!currentState && currentState.type === "random" && currentState.generation === generation;
+  }
+}
+
+export const __soundscapeAmbienceRuntimeInternals = {
+  createAmbienceKey,
+  createLayerFingerprint,
+  defaultResolveSoundByUuid,
+  randomDelayMs,
+};

--- a/src/soundscapes/soundscape-api.ts
+++ b/src/soundscapes/soundscape-api.ts
@@ -1,6 +1,16 @@
 import type { PersistentSoundscapeLibrarySnapshot, ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
 import { getStoredSoundscapeLibrarySnapshot, resolveStoredSoundscapeState } from "./soundscape-accessors";
 import {
+  getSoundscapeAmbienceRuntimeSnapshot,
+  playStoredSoundscapeMoment,
+  stopStoredSoundscapeAmbience,
+  syncStoredSoundscapeAmbience,
+} from "./soundscape-ambience-controller";
+import type {
+  SoundscapeAmbienceRuntimeSnapshot,
+  SoundscapeMomentPlaybackResult,
+} from "./soundscape-ambience-runtime";
+import {
   getSoundscapeMusicRuntimeSnapshot,
   stopStoredSoundscapeMusic,
   syncStoredSoundscapeMusic,
@@ -15,6 +25,10 @@ export interface FthSoundscapeDebugApi {
   syncMusic: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => Promise<SoundscapeMusicRuntimeSnapshot>;
   stopMusic: () => Promise<void>;
   getMusicState: () => SoundscapeMusicRuntimeSnapshot;
+  syncAmbience: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => Promise<SoundscapeAmbienceRuntimeSnapshot>;
+  stopAmbience: () => Promise<void>;
+  getAmbienceState: () => SoundscapeAmbienceRuntimeSnapshot;
+  playMoment: (momentId: string, sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => Promise<SoundscapeMomentPlaybackResult>;
 }
 
 export interface FthSoundscapeApi {
@@ -30,6 +44,10 @@ export function buildSoundscapeApi(): FthSoundscapeApi {
       syncMusic: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => syncStoredSoundscapeMusic(sceneId, context),
       stopMusic: () => stopStoredSoundscapeMusic(),
       getMusicState: () => getSoundscapeMusicRuntimeSnapshot(),
+      syncAmbience: (sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => syncStoredSoundscapeAmbience(sceneId, context),
+      stopAmbience: () => stopStoredSoundscapeAmbience(),
+      getAmbienceState: () => getSoundscapeAmbienceRuntimeSnapshot(),
+      playMoment: (momentId: string, sceneId?: string, context?: Partial<SoundscapeTriggerContext>) => playStoredSoundscapeMoment(momentId, sceneId, context),
     },
   };
 }

--- a/src/types/foundry.d.ts
+++ b/src/types/foundry.d.ts
@@ -176,6 +176,7 @@ export interface FoundryPlaylistSound extends FoundryDocument {
   playing?: boolean;
   repeat?: boolean;
   sort?: number;
+  sound?: FoundryAudioSound | null;
   load?(): Promise<void>;
   sync?(): void;
 }
@@ -185,6 +186,15 @@ export interface FoundryPlaylist extends FoundryDocument {
   playSound?(sound: FoundryPlaylistSound): Promise<FoundryPlaylist>;
   stopSound?(sound: FoundryPlaylistSound): Promise<FoundryPlaylist>;
   stopAll?(): Promise<FoundryPlaylist>;
+}
+
+export interface FoundryAudioSound {
+  duration?: number;
+  loaded?: boolean;
+  loop?: boolean;
+  playing?: boolean;
+  play?(options?: Record<string, unknown>): Promise<unknown>;
+  stop?(): Promise<unknown> | void;
 }
 
 /* ── Socket ───────────────────────────────────────────────── */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export type {
   FoundryScene,
   FoundryPlaylist,
   FoundryPlaylistSound,
+  FoundryAudioSound,
   SettingRegistration,
   SettingMenuRegistration,
   FoundryCompendiumCollection,


### PR DESCRIPTION
## Summary
- add the reactive soundscapes ambience runtime and controller for loop layers, random ambience, and manual moments
- expose ambience sync/stop/state and moment playback through the soundscape debug API and extend local playlist audio typings
- cover ambience cleanup, duplicate-prevention, stale-start races, re-entrant sync races, and controller/API seams with tests

## Testing
- npm run typecheck
- npx vitest run src/soundscapes/soundscape-ambience-runtime.test.ts src/soundscapes/soundscape-ambience-controller.test.ts src/fth-api.test.ts
- npm run test
- npm run build

Closes #72
