### PR TITLE
Fix stale inactive combat soundscape triggers

### DIFF
--- a/src/soundscapes/soundscape-trigger-service.test.ts
+++ b/src/soundscapes/soundscape-trigger-service.test.ts
@@ -221,6 +221,25 @@ describe("soundscape trigger service", () => {
     }));
   });
 
+  it("ignores inactive stale combats with leftover round or turn data", async () => {
+    setWorld({
+      combatActive: false,
+      combatStarted: false,
+      combatRound: 3,
+      combatTurn: 1,
+    });
+    const mod = await loadService();
+
+    await mod.startSoundscapeTriggerService();
+
+    expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", expect.objectContaining({
+      inCombat: false,
+    }));
+    expect(mod.getSoundscapeTriggerContext()).toEqual(expect.objectContaining({
+      inCombat: false,
+    }));
+  });
+
   it("prefers Calendaria hooks and API data over core scene darkness", async () => {
     setWorld({
       sceneDarkness: 0.9,

--- a/src/soundscapes/soundscape-trigger-service.ts
+++ b/src/soundscapes/soundscape-trigger-service.ts
@@ -96,6 +96,11 @@ function isCombatStarted(combat: CombatLike | null | undefined): boolean {
   return (round ?? 0) > 0 || turn !== null;
 }
 
+function isActiveCombatStarted(combat: CombatLike | null | undefined): boolean {
+  if (!combat || combat.active === false) return false;
+  return isCombatStarted(combat);
+}
+
 function resolveTimeOfDayFromCalendaria(api: CalendariaApiLike | null): SoundscapeTimeOfDay | null {
   if (!api) return null;
   if (api.isDaytime?.() === true) return "day";
@@ -223,11 +228,11 @@ export class SoundscapeTriggerService {
   private readCombatPatch(): ProviderPatch {
     const game = getGame();
     const activeCombat = game?.combat;
-    if (isCombatStarted(activeCombat)) {
+    if (isActiveCombatStarted(activeCombat)) {
       return { inCombat: true };
     }
     const combats = game?.combats;
-    const inCombat = combats?.find((combat: CombatLike) => isCombatStarted(combat)) !== undefined;
+    const inCombat = combats?.find((combat: CombatLike) => isActiveCombatStarted(combat)) !== undefined;
     return { inCombat };
   }
 
@@ -315,6 +320,7 @@ export const __soundscapeTriggerServiceInternals = {
   singletonService,
   buildContextKey,
   getCalendariaApi,
+  isActiveCombatStarted,
   isCombatStarted,
   normalizeWeatherKey,
   normalizeWeatherPayload,


### PR DESCRIPTION
## Summary
- ignore inactive combats when deriving the reactive soundscape combat trigger
- add regression coverage for stale inactive combats with leftover round/turn data
- preserve the existing active-started and active-unstarted combat behavior

## Verification
- npx vitest run src/soundscapes/soundscape-trigger-service.test.ts src/index.test.ts src/soundscapes/soundscape-music-controller.test.ts src/soundscapes/soundscape-ambience-controller.test.ts
- npm run typecheck
- npm run test
- npm run build

Closes #88
