### PR TITLE
Issue #92: migrate soundscape storage and playback to direct audio paths

### DIFF
--- a/src/soundscapes/soundscape-accessors.test.ts
+++ b/src/soundscapes/soundscape-accessors.test.ts
@@ -52,7 +52,7 @@ describe("soundscape accessors", () => {
     await setSoundscapeWorldDefaultProfileId("forest");
 
     expect(getStoredSoundscapeLibrarySnapshot()).toMatchObject({
-      formatVersion: 1,
+      formatVersion: 2,
       profiles: {
         forest: {
           id: "forest",
@@ -144,7 +144,7 @@ describe("soundscape accessors", () => {
     const store = new Map<string, unknown>();
     store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID}`, "forest");
     store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.LIBRARY}`, JSON.stringify({
-      formatVersion: 1,
+      formatVersion: 2,
       savedAt: "2026-03-27T00:00:00.000Z",
       profiles: {
         forest: {
@@ -154,7 +154,7 @@ describe("soundscape accessors", () => {
             calm: {
               id: "calm",
               name: "Calm",
-              playlistUuids: ["Playlist.forest"],
+              audioPaths: ["music/forest.ogg"],
               selectionMode: "sequential",
               delaySeconds: 0,
             },
@@ -195,7 +195,7 @@ describe("soundscape accessors", () => {
     const store = new Map<string, unknown>();
     store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.WORLD_DEFAULT_PROFILE_ID}`, "forest");
     store.set(`${MOD}.${SOUNDSCAPE_SETTINGS.LIBRARY}`, JSON.stringify({
-      formatVersion: 1,
+      formatVersion: 2,
       savedAt: "2026-03-27T00:00:00.000Z",
       profiles: {
         forest: {
@@ -205,7 +205,7 @@ describe("soundscape accessors", () => {
             calm: {
               id: "calm",
               name: "Calm",
-              playlistUuids: ["Playlist.calm"],
+              audioPaths: ["music/calm.ogg"],
               selectionMode: "sequential",
               delaySeconds: 0,
             },
@@ -215,7 +215,7 @@ describe("soundscape accessors", () => {
               id: "birds",
               name: "Birds",
               mode: "loop",
-              soundUuids: ["PlaylistSound.birds"],
+              audioPaths: ["ambience/birds.ogg"],
               minDelaySeconds: 0,
               maxDelaySeconds: 0,
             },

--- a/src/soundscapes/soundscape-ambience-controller.test.ts
+++ b/src/soundscapes/soundscape-ambience-controller.test.ts
@@ -6,9 +6,9 @@ const runtimeStopMock = vi.fn();
 const runtimeGetSnapshotMock = vi.fn(() => ({
   activeAmbienceKey: null,
   activeLayerIds: [],
-  loopSoundUuids: [],
+  loopAudioPaths: [],
   randomLayerIds: [],
-  activeRandomSoundUuids: [],
+  activeRandomAudioPaths: [],
   pendingRandomLayerIds: [],
   lastError: null,
 }));
@@ -30,17 +30,12 @@ vi.mock("./soundscape-ambience-runtime", () => ({
 describe("soundscape ambience controller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    resolveStoredSoundscapeStateMock.mockReturnValue({
-      profileId: "forest",
-      ambienceLayerIds: ["wind"],
-      ambienceLayers: [{ id: "wind" }],
-      soundMoments: [{ id: "sting" }],
-    });
+    resolveStoredSoundscapeStateMock.mockReturnValue({ profileId: "forest", soundMoments: [] });
     runtimeSyncMock.mockResolvedValue(runtimeGetSnapshotMock());
     runtimeStopMock.mockResolvedValue(undefined);
     runtimePlayMomentFromStateMock.mockResolvedValue({
       momentId: "sting",
-      soundUuid: "PlaylistSound.sting",
+      audioPath: "moments/sting.ogg",
       played: true,
       error: null,
     });
@@ -49,32 +44,19 @@ describe("soundscape ambience controller", () => {
   it("resolves stored state and hands it to the singleton runtime", async () => {
     const mod = await import("./soundscape-ambience-controller");
 
-    await mod.syncStoredSoundscapeAmbience("scene-1", { weather: "rain" });
+    await mod.syncStoredSoundscapeAmbience("scene-1", { inCombat: true });
 
-    expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", { weather: "rain" });
-    expect(runtimeSyncMock).toHaveBeenCalledWith(expect.objectContaining({
-      profileId: "forest",
-      ambienceLayerIds: ["wind"],
-    }));
+    expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", { inCombat: true });
+    expect(runtimeSyncMock).toHaveBeenCalledWith({ profileId: "forest", soundMoments: [] });
   });
 
-  it("plays moments from the cached active soundscape state", async () => {
+  it("plays a moment against the last resolved state", async () => {
     const mod = await import("./soundscape-ambience-controller");
 
-    await mod.syncStoredSoundscapeAmbience("scene-1");
-    await mod.playStoredSoundscapeMoment("sting");
+    await mod.syncStoredSoundscapeAmbience();
+    const result = await mod.playStoredSoundscapeMoment("sting");
 
-    expect(runtimePlayMomentFromStateMock).toHaveBeenCalledWith(expect.objectContaining({
-      profileId: "forest",
-    }), "sting");
-  });
-
-  it("stops playback and exposes the runtime snapshot", async () => {
-    const mod = await import("./soundscape-ambience-controller");
-
-    await mod.stopStoredSoundscapeAmbience();
-
-    expect(runtimeStopMock).toHaveBeenCalledTimes(1);
-    expect(mod.getSoundscapeAmbienceRuntimeSnapshot()).toEqual(runtimeGetSnapshotMock.mock.results[0]?.value);
+    expect(runtimePlayMomentFromStateMock).toHaveBeenCalledWith({ profileId: "forest", soundMoments: [] }, "sting");
+    expect(result.audioPath).toBe("moments/sting.ogg");
   });
 });

--- a/src/soundscapes/soundscape-ambience-runtime.test.ts
+++ b/src/soundscapes/soundscape-ambience-runtime.test.ts
@@ -9,21 +9,12 @@ interface FakeTimerHandle {
   cleared: boolean;
 }
 
-interface FakeSound {
-  duration?: number;
-  playing?: boolean;
-  play: (options?: Record<string, unknown>) => Promise<unknown>;
-  stop: () => Promise<unknown>;
-}
-
-interface FakeSoundDocument {
-  id: string;
-  uuid: string;
-  name: string;
+interface FakeAudioHandle {
   path: string;
-  sound: FakeSound;
+  durationSeconds: number;
   load: () => Promise<void>;
-  sync: () => void;
+  play: (options?: { loop?: boolean }) => Promise<boolean>;
+  stop: () => Promise<void>;
 }
 
 function createFakeTimers() {
@@ -50,24 +41,13 @@ function createFakeTimers() {
   };
 }
 
-function createSoundDocument(uuid: string, durationSeconds = 1): FakeSoundDocument {
-  const play = vi.fn(async (_options?: Record<string, unknown>): Promise<void> => {});
-  const stop = vi.fn(async (): Promise<void> => {});
-  const load = vi.fn(async (): Promise<void> => {});
-  const sync = vi.fn((): void => {});
-
+function createAudioHandle(path: string, durationSeconds = 1): FakeAudioHandle {
   return {
-    id: uuid.split(".").at(-1) ?? uuid,
-    uuid,
-    name: uuid,
-    path: `sounds/${uuid}.ogg`,
-    sound: {
-      duration: durationSeconds,
-      play,
-      stop,
-    },
-    load,
-    sync,
+    path,
+    durationSeconds,
+    load: vi.fn(async (): Promise<void> => {}),
+    play: vi.fn(async (): Promise<boolean> => true),
+    stop: vi.fn(async (): Promise<void> => {}),
   };
 }
 
@@ -102,22 +82,14 @@ async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
 }
 
-function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((nextResolve) => {
-    resolve = nextResolve;
-  });
-  return { promise, resolve };
-}
-
 describe("soundscape ambience runtime", () => {
-  it("starts loop layers and prevents duplicate ambience playback for shared sources", async () => {
-    const wind = createSoundDocument("PlaylistSound.wind");
-    const birds = createSoundDocument("PlaylistSound.birds");
+  it("starts loop layers and prevents duplicate playback for shared audio paths", async () => {
+    const wind = createAudioHandle("ambience/wind.ogg");
+    const birds = createAudioHandle("ambience/birds.ogg");
     const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async (uuid) => {
-        if (uuid === "PlaylistSound.wind") return wind;
-        if (uuid === "PlaylistSound.birds") return birds;
+      resolveAudioPath: async (path) => {
+        if (path === wind.path) return wind;
+        if (path === birds.path) return birds;
         return null;
       },
     });
@@ -128,7 +100,7 @@ describe("soundscape ambience runtime", () => {
           id: "forest-loop",
           name: "Forest Loop",
           mode: "loop",
-          soundUuids: ["PlaylistSound.wind", "PlaylistSound.birds"],
+          audioPaths: [wind.path, birds.path],
           minDelaySeconds: 0,
           maxDelaySeconds: 0,
         },
@@ -136,26 +108,26 @@ describe("soundscape ambience runtime", () => {
           id: "mist-loop",
           name: "Mist Loop",
           mode: "loop",
-          soundUuids: ["PlaylistSound.wind"],
+          audioPaths: [wind.path],
           minDelaySeconds: 0,
           maxDelaySeconds: 0,
         },
       ],
     }));
 
-    expect(wind.sound.play).toHaveBeenCalledTimes(1);
-    expect(birds.sound.play).toHaveBeenCalledTimes(1);
+    expect(wind.play).toHaveBeenCalledTimes(1);
+    expect(birds.play).toHaveBeenCalledTimes(1);
     expect(runtime.getSnapshot()).toMatchObject({
       activeLayerIds: ["forest-loop", "mist-loop"],
-      loopSoundUuids: ["PlaylistSound.birds", "PlaylistSound.wind"],
+      loopAudioPaths: ["ambience/birds.ogg", "ambience/wind.ogg"],
       randomLayerIds: [],
     });
   });
 
   it("restarts a shared loop for the remaining layer when the original owner is removed", async () => {
-    const wind = createSoundDocument("PlaylistSound.wind");
+    const wind = createAudioHandle("ambience/wind.ogg");
     const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => wind,
+      resolveAudioPath: async () => wind,
     });
 
     await runtime.sync(createResolvedState({
@@ -164,7 +136,7 @@ describe("soundscape ambience runtime", () => {
           id: "forest-loop",
           name: "Forest Loop",
           mode: "loop",
-          soundUuids: ["PlaylistSound.wind"],
+          audioPaths: [wind.path],
           minDelaySeconds: 0,
           maxDelaySeconds: 0,
         },
@@ -172,7 +144,7 @@ describe("soundscape ambience runtime", () => {
           id: "mist-loop",
           name: "Mist Loop",
           mode: "loop",
-          soundUuids: ["PlaylistSound.wind"],
+          audioPaths: [wind.path],
           minDelaySeconds: 0,
           maxDelaySeconds: 0,
         },
@@ -185,30 +157,30 @@ describe("soundscape ambience runtime", () => {
           id: "mist-loop",
           name: "Mist Loop",
           mode: "loop",
-          soundUuids: ["PlaylistSound.wind"],
+          audioPaths: [wind.path],
           minDelaySeconds: 0,
           maxDelaySeconds: 0,
         },
       ],
     }));
 
-    expect(wind.sound.play).toHaveBeenCalledTimes(2);
-    expect(wind.sound.stop).toHaveBeenCalledTimes(1);
+    expect(wind.play).toHaveBeenCalledTimes(2);
+    expect(wind.stop).toHaveBeenCalledTimes(1);
     expect(runtime.getSnapshot()).toMatchObject({
       activeLayerIds: ["mist-loop"],
-      loopSoundUuids: ["PlaylistSound.wind"],
+      loopAudioPaths: ["ambience/wind.ogg"],
     });
   });
 
   it("schedules random ambience layers and avoids immediate repeats when alternatives exist", async () => {
     const timers = createFakeTimers();
-    const gustA = createSoundDocument("PlaylistSound.gust-a", 2);
-    const gustB = createSoundDocument("PlaylistSound.gust-b", 2);
+    const gustA = createAudioHandle("ambience/gust-a.ogg", 2);
+    const gustB = createAudioHandle("ambience/gust-b.ogg", 2);
     const randomValues = [0, 0, 0];
     const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async (uuid) => {
-        if (uuid === "PlaylistSound.gust-a") return gustA;
-        if (uuid === "PlaylistSound.gust-b") return gustB;
+      resolveAudioPath: async (path) => {
+        if (path === gustA.path) return gustA;
+        if (path === gustB.path) return gustB;
         return null;
       },
       timers: timers.api,
@@ -220,261 +192,68 @@ describe("soundscape ambience runtime", () => {
         id: "winds",
         name: "Winds",
         mode: "random",
-        soundUuids: ["PlaylistSound.gust-a", "PlaylistSound.gust-b"],
-        minDelaySeconds: 1,
-        maxDelaySeconds: 3,
+        audioPaths: [gustA.path, gustB.path],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
       }],
     }));
-
-    expect(timers.handles[0]?.delay).toBe(1000);
 
     timers.runNext();
     await flushAsyncWork();
 
-    expect(gustA.sound.play).toHaveBeenCalledTimes(1);
     expect(runtime.getSnapshot()).toMatchObject({
-      activeRandomSoundUuids: ["PlaylistSound.gust-a"],
-      pendingRandomLayerIds: [],
+      activeRandomAudioPaths: ["ambience/gust-a.ogg"],
     });
 
     timers.runNext();
     await flushAsyncWork();
-
-    expect(timers.handles.find((handle) => !handle.cleared)?.delay).toBe(1000);
-
     timers.runNext();
     await flushAsyncWork();
 
-    expect(gustB.sound.play).toHaveBeenCalledTimes(1);
     expect(runtime.getSnapshot()).toMatchObject({
-      activeRandomSoundUuids: ["PlaylistSound.gust-b"],
+      activeRandomAudioPaths: ["ambience/gust-b.ogg"],
     });
   });
 
-  it("cleans up obsolete loops, active random playback, and timers when ambience changes", async () => {
-    const timers = createFakeTimers();
-    const rain = createSoundDocument("PlaylistSound.rain", 10);
+  it("plays manual moments using direct audio paths", async () => {
+    const sting = createAudioHandle("moments/sting.ogg", 1);
     const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => rain,
-      timers: timers.api,
-      random: () => 0,
+      resolveAudioPath: async () => sting,
     });
 
-    await runtime.sync(createResolvedState({
-      ambienceLayers: [{
-        id: "rain-loop",
-        name: "Rain Loop",
-        mode: "loop",
-        soundUuids: ["PlaylistSound.rain"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }, {
-        id: "rain-hits",
-        name: "Rain Hits",
-        mode: "random",
-        soundUuids: ["PlaylistSound.rain"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }],
-    }));
-
-    timers.runNext();
-    await flushAsyncWork();
-
-    await runtime.sync(createResolvedState({
-      ambienceLayers: [],
-    }));
-
-    expect(rain.sound.stop).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeAmbienceKey: null,
-      activeLayerIds: [],
-      loopSoundUuids: [],
-      pendingRandomLayerIds: [],
+    const result = await runtime.playMoment({
+      id: "sting",
+      name: "Sting",
+      audioPaths: [sting.path],
+      selectionMode: "single",
     });
-    expect(timers.handles.every((handle) => handle.cleared)).toBe(true);
-  });
-
-  it("plays manual sound moments on demand without mutating ambience state", async () => {
-    const sting = createSoundDocument("PlaylistSound.sting");
-    const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => sting,
-    });
-
-    await runtime.sync(createResolvedState({
-      ambienceLayers: [{
-        id: "forest-loop",
-        name: "Forest Loop",
-        mode: "loop",
-        soundUuids: ["PlaylistSound.sting"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }],
-      soundMoments: [{
-        id: "sting",
-        name: "Sting",
-        soundUuids: ["PlaylistSound.sting"],
-        selectionMode: "single",
-      }],
-    }));
-
-    const before = runtime.getSnapshot();
-    const result = await runtime.playMomentFromState(createResolvedState({
-      soundMoments: [{
-        id: "sting",
-        name: "Sting",
-        soundUuids: ["PlaylistSound.sting"],
-        selectionMode: "single",
-      }],
-    }), "sting");
 
     expect(result).toEqual({
       momentId: "sting",
-      soundUuid: "PlaylistSound.sting",
+      audioPath: "moments/sting.ogg",
       played: true,
       error: null,
     });
-    expect(sting.sound.play).toHaveBeenCalledTimes(2);
-    expect(runtime.getSnapshot()).toEqual(before);
+    expect(sting.play).toHaveBeenCalledTimes(1);
   });
 
-  it("does not start a loop after its layer is removed while sound resolution is still pending", async () => {
-    const deferred = createDeferred<FakeSoundDocument | null>();
-    const wind = createSoundDocument("PlaylistSound.wind");
+  it("reports missing audio paths cleanly", async () => {
     const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => await deferred.promise,
+      resolveAudioPath: async () => null,
     });
 
-    const startingSync = runtime.sync(createResolvedState({
-      ambienceLayers: [{
-        id: "forest-loop",
-        name: "Forest Loop",
-        mode: "loop",
-        soundUuids: ["PlaylistSound.wind"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }],
-    }));
-    await flushAsyncWork();
-
-    const stoppingSync = runtime.sync(createResolvedState({ ambienceLayers: [] }));
-    deferred.resolve(wind);
-
-    await startingSync;
-    await stoppingSync;
-
-    expect(wind.sound.play).not.toHaveBeenCalled();
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeLayerIds: [],
-      loopSoundUuids: [],
-    });
-  });
-
-  it("does not start random ambience after its layer is removed while sound resolution is still pending", async () => {
-    const timers = createFakeTimers();
-    const deferred = createDeferred<FakeSoundDocument | null>();
-    const rain = createSoundDocument("PlaylistSound.rain");
-    const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => await deferred.promise,
-      timers: timers.api,
-      random: () => 0,
+    const result = await runtime.playMoment({
+      id: "missing",
+      name: "Missing",
+      audioPaths: ["moments/missing.ogg"],
+      selectionMode: "single",
     });
 
-    await runtime.sync(createResolvedState({
-      ambienceLayers: [{
-        id: "rain-hits",
-        name: "Rain Hits",
-        mode: "random",
-        soundUuids: ["PlaylistSound.rain"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }],
-    }));
-
-    timers.runNext();
-    await flushAsyncWork();
-
-    const stoppingSync = runtime.sync(createResolvedState({ ambienceLayers: [] }));
-    deferred.resolve(rain);
-
-    await stoppingSync;
-    await flushAsyncWork();
-
-    expect(rain.sound.play).not.toHaveBeenCalled();
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeLayerIds: [],
-      activeRandomSoundUuids: [],
-      pendingRandomLayerIds: [],
-    });
-  });
-
-  it("does not double-start the same loop when sync is called again during pending startup", async () => {
-    const deferred = createDeferred<FakeSoundDocument | null>();
-    const wind = createSoundDocument("PlaylistSound.wind");
-    const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => await deferred.promise,
-    });
-    const state = createResolvedState({
-      ambienceLayers: [{
-        id: "forest-loop",
-        name: "Forest Loop",
-        mode: "loop",
-        soundUuids: ["PlaylistSound.wind"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }],
-    });
-
-    const firstSync = runtime.sync(state);
-    await flushAsyncWork();
-    const secondSync = runtime.sync(state);
-    deferred.resolve(wind);
-
-    await firstSync;
-    await secondSync;
-
-    expect(wind.sound.play).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeLayerIds: ["forest-loop"],
-      loopSoundUuids: ["PlaylistSound.wind"],
-    });
-  });
-
-  it("does not reschedule the same random layer while startup is already pending", async () => {
-    const timers = createFakeTimers();
-    const deferred = createDeferred<FakeSoundDocument | null>();
-    const rain = createSoundDocument("PlaylistSound.rain");
-    const runtime = new SoundscapeAmbienceRuntime({
-      resolveSoundByUuid: async () => await deferred.promise,
-      timers: timers.api,
-      random: () => 0,
-    });
-    const state = createResolvedState({
-      ambienceLayers: [{
-        id: "rain-hits",
-        name: "Rain Hits",
-        mode: "random",
-        soundUuids: ["PlaylistSound.rain"],
-        minDelaySeconds: 0,
-        maxDelaySeconds: 0,
-      }],
-    });
-
-    await runtime.sync(state);
-    timers.runNext();
-    await flushAsyncWork();
-
-    await runtime.sync(state);
-
-    deferred.resolve(rain);
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(rain.sound.play).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeLayerIds: ["rain-hits"],
-      activeRandomSoundUuids: ["PlaylistSound.rain"],
-      pendingRandomLayerIds: [],
+    expect(result).toEqual({
+      momentId: "missing",
+      audioPath: "moments/missing.ogg",
+      played: false,
+      error: 'Sound moment "Missing" could not resolve audio path "moments/missing.ogg".',
     });
   });
 });

--- a/src/soundscapes/soundscape-ambience-runtime.ts
+++ b/src/soundscapes/soundscape-ambience-runtime.ts
@@ -1,4 +1,4 @@
-import { fromUuid } from "../types";
+import { resolveAudioPathPlayback, type SoundscapeAudioHandle } from "./soundscape-audio-playback";
 import type {
   ResolvedSoundscapeState,
   SoundscapeAmbienceLayer,
@@ -11,36 +11,19 @@ interface TimerApi {
 }
 
 interface RuntimeDeps {
-  resolveSoundByUuid?: (uuid: string) => Promise<RuntimeSoundDocumentLike | null>;
+  resolveAudioPath?: (path: string) => Promise<SoundscapeAudioHandle | null>;
   timers?: TimerApi;
   random?: () => number;
 }
 
-interface RuntimeSoundLike {
-  duration?: number;
-  playing?: boolean;
-  play?: (options?: Record<string, unknown>) => Promise<unknown>;
-  stop?: () => Promise<unknown> | void;
-}
-
-interface RuntimeSoundDocumentLike {
-  id: string;
-  uuid?: string;
-  name?: string;
-  path?: string;
-  sound?: RuntimeSoundLike | null;
-  load?: () => Promise<void>;
-  sync?: () => void;
-}
-
 interface ActiveLoopSound {
-  soundUuid: string;
-  doc: RuntimeSoundDocumentLike;
+  audioPath: string;
+  handle: SoundscapeAudioHandle;
 }
 
 interface ActiveRandomSound {
-  soundUuid: string;
-  doc: RuntimeSoundDocumentLike;
+  audioPath: string;
+  handle: SoundscapeAudioHandle;
   cleanupTimer: unknown | null;
 }
 
@@ -50,7 +33,7 @@ interface LoopLayerRuntimeState {
   fingerprint: string;
   generation: number;
   loopSounds: Map<string, ActiveLoopSound>;
-  pendingSoundUuids: Set<string>;
+  pendingAudioPaths: Set<string>;
 }
 
 interface RandomLayerRuntimeState {
@@ -59,8 +42,8 @@ interface RandomLayerRuntimeState {
   fingerprint: string;
   scheduleTimer: unknown | null;
   activeSound: ActiveRandomSound | null;
-  lastPlayedSoundUuid: string | null;
-  pendingStartSoundUuid: string | null;
+  lastPlayedAudioPath: string | null;
+  pendingStartAudioPath: string | null;
   generation: number;
 }
 
@@ -74,16 +57,16 @@ const DEFAULT_TIMERS: TimerApi = {
 export interface SoundscapeAmbienceRuntimeSnapshot {
   activeAmbienceKey: string | null;
   activeLayerIds: string[];
-  loopSoundUuids: string[];
+  loopAudioPaths: string[];
   randomLayerIds: string[];
-  activeRandomSoundUuids: string[];
+  activeRandomAudioPaths: string[];
   pendingRandomLayerIds: string[];
   lastError: string | null;
 }
 
 export interface SoundscapeMomentPlaybackResult {
   momentId: string;
-  soundUuid: string | null;
+  audioPath: string | null;
   played: boolean;
   error: string | null;
 }
@@ -97,7 +80,7 @@ function createLayerFingerprint(layer: SoundscapeAmbienceLayer): string {
     layer.mode,
     layer.minDelaySeconds,
     layer.maxDelaySeconds,
-    ...layer.soundUuids,
+    ...layer.audioPaths,
   ].join("|");
 }
 
@@ -106,12 +89,6 @@ function randomDelayMs(layer: SoundscapeAmbienceLayer, random: () => number): nu
   const maxMs = Math.max(minMs, layer.maxDelaySeconds * 1000);
   if (maxMs <= minMs) return minMs;
   return Math.round(minMs + ((maxMs - minMs) * random()));
-}
-
-async function defaultResolveSoundByUuid(uuid: string): Promise<RuntimeSoundDocumentLike | null> {
-  const resolved = await fromUuid(uuid);
-  if (!resolved || typeof resolved.id !== "string") return null;
-  return resolved as RuntimeSoundDocumentLike;
 }
 
 function pickRandomIndex(random: () => number, length: number, lastIndex: number): number {
@@ -130,7 +107,7 @@ export class SoundscapeAmbienceRuntime {
 
   constructor(deps: RuntimeDeps = {}) {
     this.deps = {
-      resolveSoundByUuid: deps.resolveSoundByUuid ?? defaultResolveSoundByUuid,
+      resolveAudioPath: deps.resolveAudioPath ?? resolveAudioPathPlayback,
       timers: deps.timers ?? DEFAULT_TIMERS,
       random: deps.random ?? Math.random,
     };
@@ -138,21 +115,21 @@ export class SoundscapeAmbienceRuntime {
 
   getSnapshot(): SoundscapeAmbienceRuntimeSnapshot {
     const activeLayerIds = [...this.activeLayers.keys()].sort();
-    const loopSoundUuids = [...this.activeAmbienceOwners.entries()]
-      .filter(([soundUuid, layerId]) => {
-        void soundUuid;
+    const loopAudioPaths = [...this.activeAmbienceOwners.entries()]
+      .filter(([audioPath, layerId]) => {
+        void audioPath;
         const state = this.activeLayers.get(layerId);
         return state?.type === "loop";
       })
-      .map(([soundUuid]) => soundUuid)
+      .map(([audioPath]) => audioPath)
       .sort();
     const randomLayerIds = [...this.activeLayers.values()]
       .filter((state): state is RandomLayerRuntimeState => state.type === "random")
       .map((state) => state.layer.id)
       .sort();
-    const activeRandomSoundUuids = [...this.activeLayers.values()]
+    const activeRandomAudioPaths = [...this.activeLayers.values()]
       .filter((state): state is RandomLayerRuntimeState => state.type === "random")
-      .flatMap((state) => state.activeSound ? [state.activeSound.soundUuid] : [])
+      .flatMap((state) => state.activeSound ? [state.activeSound.audioPath] : [])
       .sort();
     const pendingRandomLayerIds = [...this.activeLayers.values()]
       .filter((state): state is RandomLayerRuntimeState => state.type === "random")
@@ -162,9 +139,9 @@ export class SoundscapeAmbienceRuntime {
     return {
       activeAmbienceKey: this.activeAmbienceKey,
       activeLayerIds,
-      loopSoundUuids,
+      loopAudioPaths,
       randomLayerIds,
-      activeRandomSoundUuids,
+      activeRandomAudioPaths,
       pendingRandomLayerIds,
       lastError: this.lastError,
     };
@@ -194,7 +171,7 @@ export class SoundscapeAmbienceRuntime {
           fingerprint: createLayerFingerprint(layer),
           generation: 0,
           loopSounds: new Map(),
-          pendingSoundUuids: new Set(),
+          pendingAudioPaths: new Set(),
         };
         this.activeLayers.set(layer.id, loopState);
       } else if (!activeState) {
@@ -204,8 +181,8 @@ export class SoundscapeAmbienceRuntime {
           fingerprint: createLayerFingerprint(layer),
           scheduleTimer: null,
           activeSound: null,
-          lastPlayedSoundUuid: null,
-          pendingStartSoundUuid: null,
+          lastPlayedAudioPath: null,
+          pendingStartAudioPath: null,
           generation: 0,
         };
         this.activeLayers.set(layer.id, randomState);
@@ -245,37 +222,37 @@ export class SoundscapeAmbienceRuntime {
     if (!moment) {
       return {
         momentId: "",
-        soundUuid: null,
+        audioPath: null,
         played: false,
         error: "No sound moment is available to play.",
       };
     }
 
-    const selected = this.selectMomentSoundUuid(moment);
+    const selected = this.selectMomentAudioPath(moment);
     if (!selected) {
       return {
         momentId: moment.id,
-        soundUuid: null,
+        audioPath: null,
         played: false,
         error: `Sound moment "${moment.name}" has no playable sounds.`,
       };
     }
 
-    const doc = await this.deps.resolveSoundByUuid(selected);
-    if (!doc) {
+    const handle = await this.deps.resolveAudioPath(selected);
+    if (!handle) {
       return {
         momentId: moment.id,
-        soundUuid: selected,
+        audioPath: selected,
         played: false,
-        error: `Sound moment "${moment.name}" could not resolve audio document "${selected}".`,
+        error: `Sound moment "${moment.name}" could not resolve audio path "${selected}".`,
       };
     }
 
-    const started = await this.startSoundPlayback(doc, false);
+    const started = await this.startSoundPlayback(handle, false);
     if (!started) {
       return {
         momentId: moment.id,
-        soundUuid: selected,
+        audioPath: selected,
         played: false,
         error: `Sound moment "${moment.name}" could not start playback.`,
       };
@@ -283,7 +260,7 @@ export class SoundscapeAmbienceRuntime {
 
     return {
       momentId: moment.id,
-      soundUuid: selected,
+      audioPath: selected,
       played: true,
       error: null,
     };
@@ -296,7 +273,7 @@ export class SoundscapeAmbienceRuntime {
     if (!state) {
       return {
         momentId,
-        soundUuid: null,
+        audioPath: null,
         played: false,
         error: "No active soundscape state is available.",
       };
@@ -306,7 +283,7 @@ export class SoundscapeAmbienceRuntime {
     if (!moment) {
       return {
         momentId,
-        soundUuid: null,
+        audioPath: null,
         played: false,
         error: `Sound moment "${momentId}" is not available in the active soundscape.`,
       };
@@ -317,53 +294,53 @@ export class SoundscapeAmbienceRuntime {
 
   private async startLoopLayer(state: LoopLayerRuntimeState): Promise<void> {
     const generation = state.generation;
-    for (const soundUuid of state.layer.soundUuids) {
-      if (state.loopSounds.has(soundUuid) || state.pendingSoundUuids.has(soundUuid)) continue;
+    for (const audioPath of state.layer.audioPaths) {
+      if (state.loopSounds.has(audioPath) || state.pendingAudioPaths.has(audioPath)) continue;
 
-      state.pendingSoundUuids.add(soundUuid);
-      if (!this.claimAmbienceOwner(soundUuid, state.layer.id)) {
-        state.pendingSoundUuids.delete(soundUuid);
+      state.pendingAudioPaths.add(audioPath);
+      if (!this.claimAmbienceOwner(audioPath, state.layer.id)) {
+        state.pendingAudioPaths.delete(audioPath);
         continue;
       }
 
-      const doc = await this.deps.resolveSoundByUuid(soundUuid);
-      if (!doc) {
-        this.releaseAmbienceOwner(soundUuid, state.layer.id);
-        state.pendingSoundUuids.delete(soundUuid);
-        this.lastError = `Ambience layer "${state.layer.name}" could not resolve audio document "${soundUuid}".`;
+      const handle = await this.deps.resolveAudioPath(audioPath);
+      if (!handle) {
+        this.releaseAmbienceOwner(audioPath, state.layer.id);
+        state.pendingAudioPaths.delete(audioPath);
+        this.lastError = `Ambience layer "${state.layer.name}" could not resolve audio path "${audioPath}".`;
         continue;
       }
 
-      if (!this.isCurrentLoopLayer(state.layer.id, generation) || this.activeAmbienceOwners.get(soundUuid) !== state.layer.id) {
-        this.releaseAmbienceOwner(soundUuid, state.layer.id);
-        state.pendingSoundUuids.delete(soundUuid);
+      if (!this.isCurrentLoopLayer(state.layer.id, generation) || this.activeAmbienceOwners.get(audioPath) !== state.layer.id) {
+        this.releaseAmbienceOwner(audioPath, state.layer.id);
+        state.pendingAudioPaths.delete(audioPath);
         continue;
       }
 
-      const started = await this.startSoundPlayback(doc, true);
-      if (!started || !this.isCurrentLoopLayer(state.layer.id, generation) || this.activeAmbienceOwners.get(soundUuid) !== state.layer.id) {
-        this.releaseAmbienceOwner(soundUuid, state.layer.id);
-        state.pendingSoundUuids.delete(soundUuid);
-        if (started) await this.stopSoundPlayback(doc);
-        this.lastError = `Ambience layer "${state.layer.name}" could not start loop "${soundUuid}".`;
+      const started = await this.startSoundPlayback(handle, true);
+      if (!started || !this.isCurrentLoopLayer(state.layer.id, generation) || this.activeAmbienceOwners.get(audioPath) !== state.layer.id) {
+        this.releaseAmbienceOwner(audioPath, state.layer.id);
+        state.pendingAudioPaths.delete(audioPath);
+        if (started) await this.stopSoundPlayback(handle);
+        this.lastError = `Ambience layer "${state.layer.name}" could not start loop "${audioPath}".`;
         continue;
       }
 
       const currentState = this.activeLayers.get(state.layer.id);
       if (!currentState || currentState.type !== "loop" || currentState.generation !== generation) {
-        this.releaseAmbienceOwner(soundUuid, state.layer.id);
-        state.pendingSoundUuids.delete(soundUuid);
-        await this.stopSoundPlayback(doc);
+        this.releaseAmbienceOwner(audioPath, state.layer.id);
+        state.pendingAudioPaths.delete(audioPath);
+        await this.stopSoundPlayback(handle);
         continue;
       }
 
-      currentState.loopSounds.set(soundUuid, { soundUuid, doc });
-      currentState.pendingSoundUuids.delete(soundUuid);
+      currentState.loopSounds.set(audioPath, { audioPath, handle });
+      currentState.pendingAudioPaths.delete(audioPath);
     }
   }
 
   private scheduleRandomLayer(state: RandomLayerRuntimeState, explicitDelayMs?: number): void {
-    if (state.scheduleTimer || state.activeSound || state.pendingStartSoundUuid || !this.activeLayers.has(state.layer.id)) return;
+    if (state.scheduleTimer || state.activeSound || state.pendingStartAudioPath || !this.activeLayers.has(state.layer.id)) return;
 
     const delayMs = explicitDelayMs ?? randomDelayMs(state.layer, this.deps.random);
     const generation = state.generation;
@@ -377,38 +354,38 @@ export class SoundscapeAmbienceRuntime {
     const state = this.activeLayers.get(layerId);
     if (!state || state.type !== "random" || state.generation !== generation || state.activeSound) return;
 
-    const selectedSoundUuid = this.selectRandomLayerSoundUuid(state);
-    if (!selectedSoundUuid) {
+    const selectedAudioPath = this.selectRandomLayerAudioPath(state);
+    if (!selectedAudioPath) {
       this.scheduleRandomLayer(state, Math.max(0, state.layer.minDelaySeconds * 1000));
       return;
     }
-    if (!this.claimAmbienceOwner(selectedSoundUuid, state.layer.id)) {
+    if (!this.claimAmbienceOwner(selectedAudioPath, state.layer.id)) {
       this.scheduleRandomLayer(state, Math.max(0, state.layer.minDelaySeconds * 1000));
       return;
     }
-    state.pendingStartSoundUuid = selectedSoundUuid;
+    state.pendingStartAudioPath = selectedAudioPath;
 
-    const doc = await this.deps.resolveSoundByUuid(selectedSoundUuid);
-    if (!doc) {
-      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
-      state.pendingStartSoundUuid = null;
-      this.lastError = `Ambience layer "${state.layer.name}" could not resolve audio document "${selectedSoundUuid}".`;
+    const handle = await this.deps.resolveAudioPath(selectedAudioPath);
+    if (!handle) {
+      this.releaseAmbienceOwner(selectedAudioPath, state.layer.id);
+      state.pendingStartAudioPath = null;
+      this.lastError = `Ambience layer "${state.layer.name}" could not resolve audio path "${selectedAudioPath}".`;
       this.scheduleRandomLayer(state);
       return;
     }
 
-    if (!this.isCurrentRandomLayer(layerId, generation) || this.activeAmbienceOwners.get(selectedSoundUuid) !== state.layer.id) {
-      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
-      state.pendingStartSoundUuid = null;
+    if (!this.isCurrentRandomLayer(layerId, generation) || this.activeAmbienceOwners.get(selectedAudioPath) !== state.layer.id) {
+      this.releaseAmbienceOwner(selectedAudioPath, state.layer.id);
+      state.pendingStartAudioPath = null;
       return;
     }
 
-    const started = await this.startSoundPlayback(doc, false);
-    if (!started || !this.isCurrentRandomLayer(layerId, generation) || this.activeAmbienceOwners.get(selectedSoundUuid) !== state.layer.id) {
-      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
-      state.pendingStartSoundUuid = null;
-      if (started) await this.stopSoundPlayback(doc);
-      this.lastError = `Ambience layer "${state.layer.name}" could not start "${selectedSoundUuid}".`;
+    const started = await this.startSoundPlayback(handle, false);
+    if (!started || !this.isCurrentRandomLayer(layerId, generation) || this.activeAmbienceOwners.get(selectedAudioPath) !== state.layer.id) {
+      this.releaseAmbienceOwner(selectedAudioPath, state.layer.id);
+      state.pendingStartAudioPath = null;
+      if (started) await this.stopSoundPlayback(handle);
+      this.lastError = `Ambience layer "${state.layer.name}" could not start "${selectedAudioPath}".`;
       const currentState = this.activeLayers.get(layerId);
       if (currentState && currentState.type === "random" && currentState.generation === generation) {
         this.scheduleRandomLayer(currentState);
@@ -418,75 +395,72 @@ export class SoundscapeAmbienceRuntime {
 
     const currentState = this.activeLayers.get(layerId);
     if (!currentState || currentState.type !== "random" || currentState.generation !== generation) {
-      this.releaseAmbienceOwner(selectedSoundUuid, state.layer.id);
-      state.pendingStartSoundUuid = null;
-      await this.stopSoundPlayback(doc);
+      this.releaseAmbienceOwner(selectedAudioPath, state.layer.id);
+      state.pendingStartAudioPath = null;
+      await this.stopSoundPlayback(handle);
       return;
     }
 
-    currentState.lastPlayedSoundUuid = selectedSoundUuid;
-    currentState.pendingStartSoundUuid = null;
+    currentState.lastPlayedAudioPath = selectedAudioPath;
+    currentState.pendingStartAudioPath = null;
 
-    const durationMs = Math.max(0, Math.round((doc.sound?.duration ?? 0) * 1000));
+    const durationMs = Math.max(0, Math.round(handle.durationSeconds * 1000));
     const cleanupTimer = this.deps.timers.setTimeout(() => {
-      void this.finishRandomLayerSound(layerId, generation, selectedSoundUuid);
+      void this.finishRandomLayerSound(layerId, generation, selectedAudioPath);
     }, durationMs);
 
     currentState.activeSound = {
-      soundUuid: selectedSoundUuid,
-      doc,
+      audioPath: selectedAudioPath,
+      handle,
       cleanupTimer,
     };
   }
 
-  private async finishRandomLayerSound(layerId: string, generation: number, soundUuid: string): Promise<void> {
+  private async finishRandomLayerSound(layerId: string, generation: number, audioPath: string): Promise<void> {
     const state = this.activeLayers.get(layerId);
     if (!state || state.type !== "random" || state.generation !== generation) return;
-    if (!state.activeSound || state.activeSound.soundUuid !== soundUuid) return;
+    if (!state.activeSound || state.activeSound.audioPath !== audioPath) return;
 
     if (state.activeSound.cleanupTimer !== null) {
       this.deps.timers.clearTimeout(state.activeSound.cleanupTimer);
     }
 
-    this.activeAmbienceOwners.delete(soundUuid);
+    this.activeAmbienceOwners.delete(audioPath);
     state.activeSound = null;
     this.scheduleRandomLayer(state);
   }
 
-  private selectRandomLayerSoundUuid(state: RandomLayerRuntimeState): string | null {
-    const candidates = state.layer.soundUuids.filter((soundUuid) => !this.activeAmbienceOwners.has(soundUuid));
+  private selectRandomLayerAudioPath(state: RandomLayerRuntimeState): string | null {
+    const candidates = state.layer.audioPaths.filter((audioPath) => !this.activeAmbienceOwners.has(audioPath));
     if (candidates.length === 0) return null;
 
-    const lastIndex = state.lastPlayedSoundUuid ? candidates.indexOf(state.lastPlayedSoundUuid) : -1;
+    const lastIndex = state.lastPlayedAudioPath ? candidates.indexOf(state.lastPlayedAudioPath) : -1;
     return candidates[pickRandomIndex(this.deps.random, candidates.length, lastIndex)] ?? null;
   }
 
-  private selectMomentSoundUuid(moment: SoundscapeSoundMoment): string | null {
-    if (moment.soundUuids.length === 0) return null;
-    if (moment.selectionMode === "single") return moment.soundUuids[0] ?? null;
+  private selectMomentAudioPath(moment: SoundscapeSoundMoment): string | null {
+    if (moment.audioPaths.length === 0) return null;
+    if (moment.selectionMode === "single") return moment.audioPaths[0] ?? null;
 
     const lastIndex = this.lastRandomMomentIndexByMoment.get(moment.id) ?? -1;
-    const nextIndex = pickRandomIndex(this.deps.random, moment.soundUuids.length, lastIndex);
+    const nextIndex = pickRandomIndex(this.deps.random, moment.audioPaths.length, lastIndex);
     this.lastRandomMomentIndexByMoment.set(moment.id, nextIndex);
-    return moment.soundUuids[nextIndex] ?? null;
+    return moment.audioPaths[nextIndex] ?? null;
   }
 
-  private async startSoundPlayback(doc: RuntimeSoundDocumentLike, loop: boolean): Promise<boolean> {
+  private async startSoundPlayback(handle: SoundscapeAudioHandle, loop: boolean): Promise<boolean> {
     try {
-      await doc.load?.();
-      if (!doc.sound?.play) return false;
-      await doc.sound.play({ loop });
-      doc.sync?.();
-      return true;
+      await handle.load();
+      return await handle.play({ loop });
     } catch {
       return false;
     }
   }
 
-  private async stopSoundPlayback(doc: RuntimeSoundDocumentLike | null | undefined): Promise<void> {
-    if (!doc?.sound?.stop) return;
+  private async stopSoundPlayback(handle: SoundscapeAudioHandle | null | undefined): Promise<void> {
+    if (!handle) return;
     try {
-      await doc.sound.stop();
+      await handle.stop();
     } catch {
       this.lastError = "Failed to stop ambience playback cleanly.";
     }
@@ -496,15 +470,15 @@ export class SoundscapeAmbienceRuntime {
     if (state.type === "loop") {
       state.generation += 1;
       this.releaseAmbienceOwnersForLayer(layerId);
-      state.pendingSoundUuids.clear();
+      state.pendingAudioPaths.clear();
       for (const [, activeSound] of state.loopSounds.entries()) {
-        await this.stopSoundPlayback(activeSound.doc);
+        await this.stopSoundPlayback(activeSound.handle);
       }
       state.loopSounds.clear();
     } else {
       state.generation += 1;
       this.releaseAmbienceOwnersForLayer(layerId);
-      state.pendingStartSoundUuid = null;
+      state.pendingStartAudioPath = null;
       if (state.scheduleTimer !== null) {
         this.deps.timers.clearTimeout(state.scheduleTimer);
         state.scheduleTimer = null;
@@ -513,7 +487,7 @@ export class SoundscapeAmbienceRuntime {
         if (state.activeSound.cleanupTimer !== null) {
           this.deps.timers.clearTimeout(state.activeSound.cleanupTimer);
         }
-        await this.stopSoundPlayback(state.activeSound.doc);
+        await this.stopSoundPlayback(state.activeSound.handle);
       }
       state.activeSound = null;
     }
@@ -524,23 +498,23 @@ export class SoundscapeAmbienceRuntime {
     }
   }
 
-  private claimAmbienceOwner(soundUuid: string, layerId: string): boolean {
-    const currentOwner = this.activeAmbienceOwners.get(soundUuid);
+  private claimAmbienceOwner(audioPath: string, layerId: string): boolean {
+    const currentOwner = this.activeAmbienceOwners.get(audioPath);
     if (currentOwner && currentOwner !== layerId) return false;
-    this.activeAmbienceOwners.set(soundUuid, layerId);
+    this.activeAmbienceOwners.set(audioPath, layerId);
     return true;
   }
 
-  private releaseAmbienceOwner(soundUuid: string, layerId: string): void {
-    if (this.activeAmbienceOwners.get(soundUuid) === layerId) {
-      this.activeAmbienceOwners.delete(soundUuid);
+  private releaseAmbienceOwner(audioPath: string, layerId: string): void {
+    if (this.activeAmbienceOwners.get(audioPath) === layerId) {
+      this.activeAmbienceOwners.delete(audioPath);
     }
   }
 
   private releaseAmbienceOwnersForLayer(layerId: string): void {
-    for (const [soundUuid, ownerLayerId] of [...this.activeAmbienceOwners.entries()]) {
+    for (const [audioPath, ownerLayerId] of [...this.activeAmbienceOwners.entries()]) {
       if (ownerLayerId === layerId) {
-        this.activeAmbienceOwners.delete(soundUuid);
+        this.activeAmbienceOwners.delete(audioPath);
       }
     }
   }
@@ -559,6 +533,5 @@ export class SoundscapeAmbienceRuntime {
 export const __soundscapeAmbienceRuntimeInternals = {
   createAmbienceKey,
   createLayerFingerprint,
-  defaultResolveSoundByUuid,
   randomDelayMs,
 };

--- a/src/soundscapes/soundscape-audio-playback.ts
+++ b/src/soundscapes/soundscape-audio-playback.ts
@@ -1,0 +1,124 @@
+import { getGame } from "../types";
+
+interface RuntimeSoundLike {
+  duration?: number;
+  play?: (options?: Record<string, unknown>) => Promise<unknown>;
+  stop?: () => Promise<unknown> | void;
+  load?: () => Promise<void>;
+}
+
+interface RuntimeSoundFactory {
+  create?: (data: Record<string, unknown>) => Promise<RuntimeSoundLike | null | undefined>;
+  fromPath?: (path: string) => Promise<RuntimeSoundLike | null | undefined>;
+  fromSource?: (path: string) => Promise<RuntimeSoundLike | null | undefined>;
+  new (data?: unknown): RuntimeSoundLike;
+}
+
+export interface SoundscapeAudioHandle {
+  path: string;
+  durationSeconds: number;
+  load(): Promise<void>;
+  play(options?: { loop?: boolean }): Promise<boolean>;
+  stop(): Promise<void>;
+}
+
+function basename(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  return normalized.split("/").at(-1) ?? path;
+}
+
+function getSoundFactory(): RuntimeSoundFactory | null {
+  const g = globalThis as Record<string, unknown>;
+  const foundryNs = g.foundry as Record<string, unknown> | undefined;
+  const audioNs = foundryNs?.audio as Record<string, unknown> | undefined;
+  const candidate = audioNs?.Sound as RuntimeSoundFactory | undefined;
+  return candidate ?? null;
+}
+
+async function createRuntimeSound(path: string): Promise<RuntimeSoundLike | null> {
+  const Factory = getSoundFactory();
+  if (!Factory) return null;
+
+  try {
+    if (typeof Factory.create === "function") {
+      const created = await Factory.create({
+        src: path,
+        preload: true,
+        singleton: false,
+      });
+      if (created) return created;
+    }
+  } catch {
+    // Fall through to alternate factories.
+  }
+
+  try {
+    if (typeof Factory.fromPath === "function") {
+      const created = await Factory.fromPath(path);
+      if (created) return created;
+    }
+  } catch {
+    // Fall through to alternate factories.
+  }
+
+  try {
+    if (typeof Factory.fromSource === "function") {
+      const created = await Factory.fromSource(path);
+      if (created) return created;
+    }
+  } catch {
+    // Fall through to constructor fallback.
+  }
+
+  try {
+    return new Factory({ src: path });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDurationSeconds(sound: RuntimeSoundLike): number {
+  const duration = typeof sound.duration === "number" ? sound.duration : 0;
+  return Number.isFinite(duration) && duration > 0 ? duration : 0;
+}
+
+export async function resolveAudioPathPlayback(path: string): Promise<SoundscapeAudioHandle | null> {
+  const trimmedPath = path.trim();
+  if (trimmedPath.length === 0) return null;
+
+  const sound = await createRuntimeSound(trimmedPath);
+  if (!sound) return null;
+
+  return {
+    path: trimmedPath,
+    durationSeconds: normalizeDurationSeconds(sound),
+    async load(): Promise<void> {
+      await sound.load?.();
+    },
+    async play(options?: { loop?: boolean }): Promise<boolean> {
+      if (!sound.play) return false;
+      await sound.play({ loop: options?.loop === true });
+      return true;
+    },
+    async stop(): Promise<void> {
+      await sound.stop?.();
+    },
+  };
+}
+
+export function isAudioPathResolvable(path: string): Promise<boolean> {
+  return resolveAudioPathPlayback(path).then((handle) => handle !== null);
+}
+
+export function formatAudioPathLabel(path: string): string {
+  const trimmedPath = path.trim();
+  return trimmedPath.length > 0 ? basename(trimmedPath) : "Untitled Audio";
+}
+
+export const __soundscapeAudioPlaybackInternals = {
+  createRuntimeSound,
+  getSoundFactory,
+  basename,
+  normalizeDurationSeconds,
+  getFoundryVersion: () => getGame()?.version ?? null,
+};

--- a/src/soundscapes/soundscape-live-controls-app.test.tsx
+++ b/src/soundscapes/soundscape-live-controls-app.test.tsx
@@ -71,7 +71,7 @@ vi.mock("./soundscape-ambience-controller", () => ({
   playStoredSoundscapeMoment: vi.fn(async () => ({
     played: true,
     error: null,
-    soundUuid: "Compendium.fth.sound.sting",
+    audioPath: "moments/sting.ogg",
     momentId: "sting",
   })),
 }));
@@ -79,7 +79,7 @@ vi.mock("./soundscape-ambience-controller", () => ({
 vi.mock("./soundscape-music-controller", () => ({
   getSoundscapeMusicRuntimeSnapshot: vi.fn(() => ({
     activeProgramId: null,
-    activePlaylistUuid: null,
+    activeAudioPath: null,
     pendingDelayMs: null,
     lastError: null,
   })),

--- a/src/soundscapes/soundscape-live-controls-app.tsx
+++ b/src/soundscapes/soundscape-live-controls-app.tsx
@@ -162,7 +162,7 @@ function SoundscapeLiveControlsView(): JSX.Element {
     setAmbienceSnapshot(getSoundscapeAmbienceRuntimeSnapshot());
 
     if (result.played) {
-      setStatus(`Played ${momentName}${result.soundUuid ? ` (${result.soundUuid})` : ""}.`);
+      setStatus(`Played ${momentName}${result.audioPath ? ` (${result.audioPath})` : ""}.`);
     } else {
       setStatus(result.error ?? `Unable to play ${momentName}.`);
     }
@@ -226,7 +226,7 @@ function SoundscapeLiveControlsView(): JSX.Element {
                     <div className="min-w-0">
                       <div className="font-fth-cc-display text-[1.08rem] text-[#f5e5c6]">{moment.name}</div>
                       <div className="mt-1 font-fth-cc-ui text-[0.58rem] uppercase tracking-[0.18em] text-[#c7bcad]">
-                        {moment.id} · {moment.soundUuids.length} sound{moment.soundUuids.length === 1 ? "" : "s"}
+                        {moment.id} · {moment.audioPaths.length} sound{moment.audioPaths.length === 1 ? "" : "s"}
                       </div>
                     </div>
                     <LiveControlsButton
@@ -248,7 +248,7 @@ function SoundscapeLiveControlsView(): JSX.Element {
           <LiveControlsCard title="Runtime Snapshot">
             <div className="grid gap-3">
               <RuntimePill label="Music Program" value={musicSnapshot.activeProgramId ?? "Idle"} />
-              <RuntimePill label="Playlist" value={musicSnapshot.activePlaylistUuid ?? "None"} />
+              <RuntimePill label="Audio Path" value={musicSnapshot.activeAudioPath ?? "None"} />
               <RuntimePill label="Queued Delay" value={musicSnapshot.pendingDelayMs !== null ? `${musicSnapshot.pendingDelayMs} ms` : "None"} />
               <RuntimePill label="Ambience Layers" value={ambienceSnapshot.activeLayerIds.length > 0 ? ambienceSnapshot.activeLayerIds.join(", ") : "Idle"} />
               <RuntimePill label="Random Layers Pending" value={ambienceSnapshot.pendingRandomLayerIds.length > 0 ? ambienceSnapshot.pendingRandomLayerIds.join(", ") : "None"} />

--- a/src/soundscapes/soundscape-music-controller.test.ts
+++ b/src/soundscapes/soundscape-music-controller.test.ts
@@ -1,26 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveStoredSoundscapeStateMock = vi.fn();
-const getHooksMock = vi.fn();
 const runtimeSyncMock = vi.fn();
 const runtimeStopMock = vi.fn();
 const runtimeGetSnapshotMock = vi.fn(() => ({
   activeProgramKey: null,
   activeProgramId: null,
-  activePlaylistUuid: null,
-  activeSoundId: null,
+  activeAudioPath: null,
   pendingProgramKey: null,
   pendingDelayMs: null,
   lastError: null,
 }));
-const runtimeHandleTrackEndedMock = vi.fn();
 
 vi.mock("./soundscape-accessors", () => ({
   resolveStoredSoundscapeState: resolveStoredSoundscapeStateMock,
-}));
-
-vi.mock("../types", () => ({
-  getHooks: getHooksMock,
 }));
 
 vi.mock("./soundscape-music-runtime", () => ({
@@ -28,7 +21,6 @@ vi.mock("./soundscape-music-runtime", () => ({
     sync = runtimeSyncMock;
     stop = runtimeStopMock;
     getSnapshot = runtimeGetSnapshotMock;
-    handleTrackEnded = runtimeHandleTrackEndedMock;
   },
 }));
 
@@ -39,14 +31,12 @@ describe("soundscape music controller", () => {
     runtimeSyncMock.mockResolvedValue({
       activeProgramKey: "forest:calm",
       activeProgramId: "calm",
-      activePlaylistUuid: "Playlist.calm",
-      activeSoundId: "track-1",
+      activeAudioPath: "music/calm.ogg",
       pendingProgramKey: null,
       pendingDelayMs: null,
       lastError: null,
     });
     runtimeStopMock.mockResolvedValue(undefined);
-    getHooksMock.mockReturnValue({ on: vi.fn() });
   });
 
   it("resolves stored state and hands it to the singleton runtime", async () => {
@@ -56,7 +46,6 @@ describe("soundscape music controller", () => {
 
     expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", { inCombat: true });
     expect(runtimeSyncMock).toHaveBeenCalledWith({ musicProgramId: "calm" });
-    expect(getHooksMock().on).toHaveBeenCalledWith("updatePlaylistSound", expect.any(Function));
   });
 
   it("stops playback and exposes the runtime snapshot", async () => {
@@ -66,35 +55,5 @@ describe("soundscape music controller", () => {
 
     expect(runtimeStopMock).toHaveBeenCalledTimes(1);
     expect(mod.getSoundscapeMusicRuntimeSnapshot()).toEqual(runtimeGetSnapshotMock.mock.results[0]?.value);
-  });
-
-  it("treats updatePlaylistSound playback-off transitions as track completion", async () => {
-    const mod = await import("./soundscape-music-controller");
-    const controller = mod.__soundscapeMusicControllerInternals.singletonController as {
-      handlePlaylistSoundUpdate(
-        sound: {
-          id: string;
-          playing?: boolean;
-          parent?: { id?: string; uuid?: string };
-        },
-        changed: Record<string, unknown>,
-      ): void;
-    };
-
-    controller.handlePlaylistSoundUpdate({ id: "track-1", playing: false, parent: { id: "playlist-1", uuid: "Playlist.playlist-1" } }, {});
-    controller.handlePlaylistSoundUpdate({ id: "track-1", playing: true, parent: { id: "playlist-1", uuid: "Playlist.playlist-1" } }, { playing: false });
-    controller.handlePlaylistSoundUpdate({ id: "track-1", playing: true, parent: { id: "playlist-1", uuid: "Playlist.playlist-1" } }, { playing: true });
-
-    expect(runtimeHandleTrackEndedMock).toHaveBeenCalledTimes(2);
-    expect(runtimeHandleTrackEndedMock).toHaveBeenNthCalledWith(1, {
-      playlistId: "playlist-1",
-      playlistUuid: "Playlist.playlist-1",
-      soundId: "track-1",
-    });
-    expect(runtimeHandleTrackEndedMock).toHaveBeenNthCalledWith(2, {
-      playlistId: "playlist-1",
-      playlistUuid: "Playlist.playlist-1",
-      soundId: "track-1",
-    });
   });
 });

--- a/src/soundscapes/soundscape-music-controller.ts
+++ b/src/soundscapes/soundscape-music-controller.ts
@@ -1,4 +1,3 @@
-import { getHooks } from "../types";
 import { resolveStoredSoundscapeState } from "./soundscape-accessors";
 import {
   SoundscapeMusicRuntime,
@@ -6,25 +5,14 @@ import {
 } from "./soundscape-music-runtime";
 import type { ResolvedSoundscapeState, SoundscapeTriggerContext } from "./soundscape-types";
 
-interface PlaylistSoundUpdateLike {
-  id: string;
-  playing?: boolean;
-  parent?: {
-    id?: string;
-    uuid?: string;
-  } | null;
-}
-
 class SoundscapeMusicController {
   private readonly runtime: SoundscapeMusicRuntime;
-  private hooksRegistered = false;
 
   constructor(runtime = new SoundscapeMusicRuntime()) {
     this.runtime = runtime;
   }
 
   async syncResolvedState(state: ResolvedSoundscapeState | null): Promise<SoundscapeMusicRuntimeSnapshot> {
-    this.ensureHooksRegistered();
     return await this.runtime.sync(state);
   }
 
@@ -41,25 +29,6 @@ class SoundscapeMusicController {
 
   getSnapshot(): SoundscapeMusicRuntimeSnapshot {
     return this.runtime.getSnapshot();
-  }
-
-  handlePlaylistSoundUpdate(sound: PlaylistSoundUpdateLike, changed: Record<string, unknown> | null | undefined): void {
-    const playingChanged = typeof changed?.playing === "boolean" ? changed.playing : undefined;
-    const isNowStopped = playingChanged === false || (playingChanged === undefined && sound.playing === false);
-    if (!isNowStopped) return;
-    this.runtime.handleTrackEnded({
-      playlistUuid: sound.parent?.uuid ?? null,
-      playlistId: sound.parent?.id ?? null,
-      soundId: sound.id,
-    });
-  }
-
-  private ensureHooksRegistered(): void {
-    if (this.hooksRegistered) return;
-    getHooks()?.on?.("updatePlaylistSound", (sound: PlaylistSoundUpdateLike, changed: Record<string, unknown>) => {
-      this.handlePlaylistSoundUpdate(sound, changed);
-    });
-    this.hooksRegistered = true;
   }
 }
 

--- a/src/soundscapes/soundscape-music-runtime.test.ts
+++ b/src/soundscapes/soundscape-music-runtime.test.ts
@@ -9,26 +9,12 @@ interface FakeTimerHandle {
   cleared: boolean;
 }
 
-interface FakePlaylistSound {
-  id: string;
-  uuid?: string;
-  name?: string;
-  path?: string;
-  sort?: number;
-  playing?: boolean;
-  repeat?: boolean;
-  load?: () => Promise<void>;
-  sync?: () => void;
-}
-
-interface FakePlaylist {
-  id: string;
-  uuid: string;
-  name: string;
-  sounds: FakePlaylistSound[];
-  playSound: (sound: FakePlaylistSound) => Promise<unknown>;
-  stopSound?: (sound: FakePlaylistSound) => Promise<unknown>;
-  stopAll?: () => Promise<unknown>;
+interface FakeAudioHandle {
+  path: string;
+  durationSeconds: number;
+  load: () => Promise<void>;
+  play: (options?: { loop?: boolean }) => Promise<boolean>;
+  stop: () => Promise<void>;
 }
 
 function createFakeTimers() {
@@ -55,36 +41,13 @@ function createFakeTimers() {
   };
 }
 
-function createPlaylist(
-  uuid: string,
-  name: string,
-  soundIds: string[],
-): FakePlaylist {
-  const sounds = soundIds.map((soundId, index) => {
-    const load = vi.fn(async (): Promise<void> => {});
-    const sync = vi.fn((): void => {});
-
-    return {
-      id: soundId,
-      uuid: `${uuid}.${soundId}`,
-      name: soundId,
-      path: `sounds/${soundId}.ogg`,
-      sort: index,
-      load,
-      sync,
-    };
-  });
-
-  const playSound = vi.fn(async (_sound: FakePlaylistSound): Promise<void> => {});
-  const stopSound = vi.fn(async (_sound: FakePlaylistSound): Promise<void> => {});
-
+function createAudioHandle(path: string, durationSeconds = 1): FakeAudioHandle {
   return {
-    id: uuid.split(".").at(-1) ?? uuid,
-    uuid,
-    name,
-    sounds,
-    playSound,
-    stopSound,
+    path,
+    durationSeconds,
+    load: vi.fn(async (): Promise<void> => {}),
+    play: vi.fn(async (): Promise<boolean> => true),
+    stop: vi.fn(async (): Promise<void> => {}),
   };
 }
 
@@ -113,177 +76,120 @@ async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("soundscape music runtime", () => {
-  it("flattens authored playlists into deterministic track candidates", async () => {
-    const town = createPlaylist("Playlist.town", "Town", ["a", "b"]);
-    const battle = createPlaylist("Playlist.battle", "Battle", ["c"]);
+  it("resolves authored audio paths into ordered track candidates", async () => {
+    const calm = createAudioHandle("music/calm.ogg", 12);
+    const battle = createAudioHandle("music/battle.ogg", 15);
 
     const candidates = await resolveMusicTrackCandidates({
       id: "program",
       name: "Program",
-      playlistUuids: ["Playlist.town", "Playlist.battle"],
+      audioPaths: ["music/calm.ogg", "music/battle.ogg"],
       selectionMode: "sequential",
       delaySeconds: 0,
-    }, async (uuid) => {
-      if (uuid === "Playlist.town") return town;
-      if (uuid === "Playlist.battle") return battle;
+    }, async (path) => {
+      if (path === "music/calm.ogg") return calm;
+      if (path === "music/battle.ogg") return battle;
       return null;
     });
 
-    expect(candidates.map((candidate) => `${candidate.playlistUuid}:${candidate.soundId}`)).toEqual([
-      "Playlist.town:a",
-      "Playlist.town:b",
-      "Playlist.battle:c",
+    expect(candidates.map((candidate) => candidate.path)).toEqual([
+      "music/calm.ogg",
+      "music/battle.ogg",
     ]);
   });
 
-  it("plays sequential tracks and respects cooldown before the next track", async () => {
+  it("plays sequential tracks and respects delay before the next track", async () => {
     const timers = createFakeTimers();
-    const playlist = createPlaylist("Playlist.town", "Town", ["a", "b"]);
+    const first = createAudioHandle("music/town-a.ogg", 1);
+    const second = createAudioHandle("music/town-b.ogg", 1);
     const program: SoundscapeMusicProgram = {
       id: "calm",
       name: "Calm",
-      playlistUuids: ["Playlist.town"],
+      audioPaths: ["music/town-a.ogg", "music/town-b.ogg"],
       selectionMode: "sequential",
       delaySeconds: 5,
     };
     const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async () => playlist,
+      resolveAudioPath: async (path) => path === first.path ? first : second,
       timers: timers.api,
     });
 
     await runtime.sync(createResolvedState(program));
 
-    expect(playlist.playSound).toHaveBeenCalledTimes(1);
-    expect(playlist.playSound).toHaveBeenLastCalledWith(playlist.sounds[0]);
+    expect(first.play).toHaveBeenCalledTimes(1);
     expect(runtime.getSnapshot()).toMatchObject({
       activeProgramId: "calm",
-      activeSoundId: "a",
+      activeAudioPath: "music/town-a.ogg",
       pendingDelayMs: null,
     });
 
-    runtime.handleTrackEnded({ playlistUuid: "Playlist.town", playlistId: playlist.id, soundId: "a" });
+    timers.runNext();
+    await flushAsyncWork();
+
     expect(runtime.getSnapshot()).toMatchObject({
-      activeSoundId: null,
+      activeAudioPath: null,
       pendingDelayMs: 5000,
     });
 
     timers.runNext();
     await flushAsyncWork();
 
-    expect(playlist.playSound).toHaveBeenCalledTimes(2);
-    expect(playlist.playSound).toHaveBeenLastCalledWith(playlist.sounds[1]);
+    expect(second.play).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activeAudioPath: "music/town-b.ogg",
+      pendingDelayMs: null,
+    });
   });
 
   it("uses deterministic random selection without repeating immediately when alternatives exist", async () => {
-    const playlist = createPlaylist("Playlist.town", "Town", ["a", "b", "c"]);
+    const timers = createFakeTimers();
+    const handles = [
+      createAudioHandle("music/a.ogg", 1),
+      createAudioHandle("music/b.ogg", 1),
+      createAudioHandle("music/c.ogg", 1),
+    ];
     const rngValues = [0, 0];
     const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async () => playlist,
+      resolveAudioPath: async (path) => handles.find((entry) => entry.path === path) ?? null,
       random: () => rngValues.shift() ?? 0,
+      timers: timers.api,
     });
     const program: SoundscapeMusicProgram = {
       id: "wild",
       name: "Wild",
-      playlistUuids: ["Playlist.town"],
+      audioPaths: handles.map((handle) => handle.path),
       selectionMode: "random",
       delaySeconds: 0,
     };
 
     await runtime.sync(createResolvedState(program));
-    runtime.handleTrackEnded({ playlistUuid: "Playlist.town", playlistId: playlist.id, soundId: "a" });
-    await flushAsyncWork();
-
-  const playedIds = ((playlist.playSound as unknown as { mock: { calls: unknown[][] } }).mock.calls)
-    .map((call) => (call[0] as { id: string }).id);
-    expect(playedIds).toEqual(["a", "b"]);
-  });
-
-  it("ignores track-ended updates from a different playlist with the same local sound id", async () => {
-    const firstPlaylist = createPlaylist("Playlist.one", "One", ["shared"]);
-    const secondPlaylist = createPlaylist("Playlist.two", "Two", ["shared"]);
-    const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async (uuid) => uuid === "Playlist.one" ? firstPlaylist : secondPlaylist,
-    });
-
-    await runtime.sync(createResolvedState({
-      id: "calm",
-      name: "Calm",
-      playlistUuids: ["Playlist.one"],
-      selectionMode: "sequential",
-      delaySeconds: 0,
-    }));
-
-    runtime.handleTrackEnded({
-      playlistUuid: "Playlist.two",
-      playlistId: secondPlaylist.id,
-      soundId: "shared",
-    });
-    await flushAsyncWork();
-
-    expect(firstPlaylist.playSound).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
-      activePlaylistUuid: "Playlist.one",
-      activeSoundId: "shared",
-      pendingDelayMs: null,
-    });
-  });
-
-  it("clears pending timers and stops old playback when switching programs", async () => {
-    const timers = createFakeTimers();
-    const calmPlaylist = createPlaylist("Playlist.calm", "Calm", ["calm-a"]);
-    const battlePlaylist = createPlaylist("Playlist.battle", "Battle", ["battle-a"]);
-
-    const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async (uuid) => {
-        if (uuid === "Playlist.calm") return calmPlaylist;
-        if (uuid === "Playlist.battle") return battlePlaylist;
-        return null;
-      },
-      timers: timers.api,
-    });
-
-    await runtime.sync(createResolvedState({
-      id: "calm",
-      name: "Calm",
-      playlistUuids: ["Playlist.calm"],
-      selectionMode: "sequential",
-      delaySeconds: 10,
-    }));
-
-    await runtime.sync(createResolvedState({
-      id: "battle",
-      name: "Battle",
-      playlistUuids: ["Playlist.battle"],
-      selectionMode: "sequential",
-      delaySeconds: 0,
-    }));
-
-    expect(calmPlaylist.stopSound).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeProgramId: "battle",
-      pendingDelayMs: null,
-      activeSoundId: "battle-a",
-    });
-
     timers.runNext();
-    expect(battlePlaylist.playSound).toHaveBeenCalledTimes(1);
+    await flushAsyncWork();
+
+    const playedPaths = handles
+      .filter((handle) => (handle.play as unknown as { mock: { calls: unknown[][] } }).mock.calls.length > 0)
+      .map((handle) => handle.path);
+    expect(playedPaths).toEqual(["music/a.ogg", "music/b.ogg"]);
   });
 
-  it("ignores one stale end event when a program switch restarts the same track", async () => {
-    let now = 0;
-    const playlist = createPlaylist("Playlist.shared", "Shared", ["shared"]);
+  it("stops the previous track when switching programs", async () => {
+    const calm = createAudioHandle("music/calm.ogg", 10);
+    const battle = createAudioHandle("music/battle.ogg", 10);
+
     const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async () => playlist,
-      now: () => now,
+      resolveAudioPath: async (path) => path === calm.path ? calm : battle,
     });
 
     await runtime.sync(createResolvedState({
       id: "calm",
       name: "Calm",
-      playlistUuids: ["Playlist.shared"],
+      audioPaths: [calm.path],
       selectionMode: "sequential",
       delaySeconds: 0,
     }));
@@ -291,82 +197,35 @@ describe("soundscape music runtime", () => {
     await runtime.sync(createResolvedState({
       id: "battle",
       name: "Battle",
-      playlistUuids: ["Playlist.shared"],
+      audioPaths: [battle.path],
       selectionMode: "sequential",
       delaySeconds: 0,
     }));
 
-    runtime.handleTrackEnded({
-      playlistUuid: "Playlist.shared",
-      playlistId: playlist.id,
-      soundId: "shared",
-    });
-    await flushAsyncWork();
-
-    expect((playlist.playSound as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(2);
+    expect(calm.stop).toHaveBeenCalledTimes(1);
+    expect(battle.play).toHaveBeenCalledTimes(1);
     expect(runtime.getSnapshot()).toMatchObject({
       activeProgramId: "battle",
-      activePlaylistUuid: "Playlist.shared",
-      activeSoundId: "shared",
-      pendingDelayMs: null,
-    });
-
-    now = 2_000;
-    runtime.handleTrackEnded({
-      playlistUuid: "Playlist.shared",
-      playlistId: playlist.id,
-      soundId: "shared",
-    });
-    await flushAsyncWork();
-
-    expect((playlist.playSound as unknown as { mock: { calls: unknown[][] } }).mock.calls).toHaveLength(3);
-    expect(runtime.getSnapshot()).toMatchObject({
-      activeProgramId: "battle",
-      activePlaylistUuid: "Playlist.shared",
-      activeSoundId: "shared",
-      pendingDelayMs: null,
+      activeAudioPath: "music/battle.ogg",
     });
   });
 
-  it("falls back to stopAll when a playlist cannot stop an individual sound", async () => {
-    const playlist = createPlaylist("Playlist.calm", "Calm", ["calm-a"]);
-    const stopAll = vi.fn(async () => {});
-    playlist.stopSound = undefined;
-    playlist.stopAll = stopAll;
-
+  it("reports a runtime error when no playable audio files can be resolved", async () => {
     const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async () => playlist,
-    });
-
-    await runtime.sync(createResolvedState({
-      id: "calm",
-      name: "Calm",
-      playlistUuids: ["Playlist.calm"],
-      selectionMode: "sequential",
-      delaySeconds: 0,
-    }));
-    await runtime.stop();
-
-    expect(stopAll).toHaveBeenCalledTimes(1);
-  });
-
-  it("fails gracefully when music program playlists cannot be resolved", async () => {
-    const runtime = new SoundscapeMusicRuntime({
-      getPlaylistByUuid: async () => null,
+      resolveAudioPath: async () => null,
     });
 
     await runtime.sync(createResolvedState({
       id: "missing",
       name: "Missing",
-      playlistUuids: ["Playlist.missing"],
+      audioPaths: ["music/missing.ogg"],
       selectionMode: "sequential",
       delaySeconds: 0,
     }));
 
     expect(runtime.getSnapshot()).toMatchObject({
-      activeProgramId: "missing",
-      activeSoundId: null,
-      lastError: 'No valid playlist tracks could be resolved for music program "Missing".',
+      activeAudioPath: null,
+      lastError: 'No valid audio files could be resolved for music program "Missing".',
     });
   });
 });

--- a/src/soundscapes/soundscape-music-runtime.ts
+++ b/src/soundscapes/soundscape-music-runtime.ts
@@ -1,8 +1,5 @@
-import { fromUuid, getGame } from "../types";
-import type {
-  ResolvedSoundscapeState,
-  SoundscapeMusicProgram,
-} from "./soundscape-types";
+import { formatAudioPathLabel, resolveAudioPathPlayback, type SoundscapeAudioHandle } from "./soundscape-audio-playback";
+import type { ResolvedSoundscapeState, SoundscapeMusicProgram } from "./soundscape-types";
 
 interface TimerApi {
   setTimeout(callback: () => void, delay: number): unknown;
@@ -10,60 +7,25 @@ interface TimerApi {
 }
 
 interface RuntimeDeps {
-  getPlaylistByUuid?: (uuid: string) => Promise<RuntimePlaylistLike | null>;
+  resolveAudioPath?: (path: string) => Promise<SoundscapeAudioHandle | null>;
   timers?: TimerApi;
   random?: () => number;
-  now?: () => number;
-}
-
-interface RuntimePlaylistLike {
-  id: string;
-  uuid?: string;
-  name?: string;
-  sounds?: Iterable<RuntimePlaylistSoundLike>;
-  playSound?: (sound: RuntimePlaylistSoundLike) => Promise<unknown>;
-  stopSound?: (sound: RuntimePlaylistSoundLike) => Promise<unknown>;
-  stopAll?: () => Promise<unknown>;
-}
-
-interface RuntimePlaylistSoundLike {
-  id: string;
-  uuid?: string;
-  name?: string;
-  path?: string;
-  sort?: number;
-  playing?: boolean;
-  repeat?: boolean;
-  load?: () => Promise<void>;
-  sync?: () => void;
 }
 
 export interface SoundscapeMusicTrackCandidate {
-  playlistId: string;
-  playlistUuid: string;
-  playlistName: string;
-  soundId: string;
-  soundUuid: string | null;
-  soundName: string;
-  sort: number;
-  playlist: RuntimePlaylistLike;
-  sound: RuntimePlaylistSoundLike;
+  path: string;
+  label: string;
+  durationSeconds: number;
+  handle: SoundscapeAudioHandle;
 }
 
 export interface SoundscapeMusicRuntimeSnapshot {
   activeProgramKey: string | null;
   activeProgramId: string | null;
-  activePlaylistUuid: string | null;
-  activeSoundId: string | null;
+  activeAudioPath: string | null;
   pendingProgramKey: string | null;
   pendingDelayMs: number | null;
   lastError: string | null;
-}
-
-export interface SoundscapeEndedTrackRef {
-  playlistUuid?: string | null;
-  playlistId?: string | null;
-  soundId: string;
 }
 
 interface ActiveProgramContext {
@@ -72,77 +34,37 @@ interface ActiveProgramContext {
   profileId: string;
 }
 
-interface CandidateIdentity {
-  playlistId: string;
-  playlistUuid: string;
-  soundId: string;
+interface ActiveTrackContext {
+  path: string;
+  label: string;
+  handle: SoundscapeAudioHandle;
 }
-
-interface IgnoredEndedTrack {
-  key: string;
-  ignoreUntil: number;
-}
-
-const PROGRAM_SWITCH_STALE_END_GRACE_MS = 1_000;
 
 const DEFAULT_TIMERS: TimerApi = {
   setTimeout: (callback, delay) => globalThis.setTimeout(callback, delay),
   clearTimeout: (handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>),
 };
 
-function sortPlaylistSounds(sounds: RuntimePlaylistSoundLike[]): RuntimePlaylistSoundLike[] {
-  return [...sounds].sort((left, right) => {
-    const sortDelta = (left.sort ?? 0) - (right.sort ?? 0);
-    if (sortDelta !== 0) return sortDelta;
-    const nameDelta = (left.name ?? "").localeCompare(right.name ?? "");
-    if (nameDelta !== 0) return nameDelta;
-    return left.id.localeCompare(right.id);
-  });
-}
-
 function createProgramKey(profileId: string, musicProgramId: string): string {
   return `${profileId}:${musicProgramId}`;
 }
 
-async function defaultGetPlaylistByUuid(uuid: string): Promise<RuntimePlaylistLike | null> {
-  const playlists = getGame()?.playlists;
-  if (playlists) {
-    for (const playlist of playlists) {
-      if (playlist.uuid === uuid) return playlist as RuntimePlaylistLike;
-    }
-  }
-
-  const resolved = await fromUuid(uuid);
-  if (!resolved) return null;
-  return resolved as RuntimePlaylistLike;
-}
-
 export async function resolveMusicTrackCandidates(
   program: SoundscapeMusicProgram,
-  getPlaylistByUuid: (uuid: string) => Promise<RuntimePlaylistLike | null> = defaultGetPlaylistByUuid,
+  resolveAudioPath: (path: string) => Promise<SoundscapeAudioHandle | null> = resolveAudioPathPlayback,
 ): Promise<SoundscapeMusicTrackCandidate[]> {
   const candidates: SoundscapeMusicTrackCandidate[] = [];
 
-  for (const playlistUuid of program.playlistUuids) {
-    const playlist = await getPlaylistByUuid(playlistUuid);
-    if (!playlist) continue;
-
-    const sounds = sortPlaylistSounds([...(playlist.sounds ?? [])])
-      .filter((sound) => typeof sound.path === "string" && sound.path.trim().length > 0);
-
-    for (const sound of sounds) {
-      candidates.push({
-        playlistId: playlist.id,
-        playlistUuid: playlist.uuid ?? playlistUuid,
-        playlistName: playlist.name?.trim() || "Untitled Playlist",
-        soundId: sound.id,
-        soundUuid: sound.uuid ?? null,
-        soundName: sound.name?.trim() || "Untitled Track",
-        sort: sound.sort ?? 0,
-        playlist,
-        sound,
-      });
-    }
+  for (const path of program.audioPaths) {
+    const handle = await resolveAudioPath(path);
+    if (!handle) continue;
+    await handle.load();
+    candidates.push({
+      path: handle.path,
+      label: formatAudioPathLabel(handle.path),
+      durationSeconds: handle.durationSeconds,
+      handle,
+    });
   }
 
   return candidates;
@@ -153,18 +75,18 @@ export class SoundscapeMusicRuntime {
   private readonly nextSequentialIndexByProgram = new Map<string, number>();
   private readonly lastRandomIndexByProgram = new Map<string, number>();
   private activeProgram: ActiveProgramContext | null = null;
-  private activeCandidate: SoundscapeMusicTrackCandidate | null = null;
+  private activeTrack: ActiveTrackContext | null = null;
   private pendingTimer: unknown = null;
+  private trackCompletionTimer: unknown = null;
   private pendingProgramKey: string | null = null;
   private pendingDelayMs: number | null = null;
   private lastError: string | null = null;
 
   constructor(deps: RuntimeDeps = {}) {
     this.deps = {
-      getPlaylistByUuid: deps.getPlaylistByUuid ?? defaultGetPlaylistByUuid,
+      resolveAudioPath: deps.resolveAudioPath ?? resolveAudioPathPlayback,
       timers: deps.timers ?? DEFAULT_TIMERS,
       random: deps.random ?? Math.random,
-      now: deps.now ?? Date.now,
     };
   }
 
@@ -172,8 +94,7 @@ export class SoundscapeMusicRuntime {
     return {
       activeProgramKey: this.activeProgram?.key ?? null,
       activeProgramId: this.activeProgram?.program.id ?? null,
-      activePlaylistUuid: this.activeCandidate?.playlistUuid ?? null,
-      activeSoundId: this.activeCandidate?.soundId ?? null,
+      activeAudioPath: this.activeTrack?.path ?? null,
       pendingProgramKey: this.pendingProgramKey,
       pendingDelayMs: this.pendingDelayMs,
       lastError: this.lastError,
@@ -189,86 +110,70 @@ export class SoundscapeMusicRuntime {
 
     const nextKey = createProgramKey(state.profileId, state.musicProgramId);
     if (this.activeProgram?.key !== nextKey) {
-      const stoppedCandidate = await this.stopActivePlayback();
+      await this.stopActivePlayback();
       this.clearPendingTimer();
+      this.clearTrackCompletionTimer();
       this.activeProgram = {
         key: nextKey,
         program: nextProgram,
         profileId: state.profileId,
       };
       await this.playNextCandidate(nextProgram, nextKey);
-      this.primeIgnoredStaleEndEvent(stoppedCandidate);
       return this.getSnapshot();
     }
 
-    if (!this.activeCandidate && !this.pendingTimer) {
+    if (!this.activeTrack && !this.pendingTimer) {
       await this.playNextCandidate(nextProgram, nextKey);
     }
 
     return this.getSnapshot();
   }
 
-  handleTrackEnded(ref: SoundscapeEndedTrackRef): void {
-    if (!this.activeProgram || !this.activeCandidate) return;
-    if (ref.soundId !== this.activeCandidate.soundId) return;
-    if (ref.playlistUuid && ref.playlistUuid !== this.activeCandidate.playlistUuid) return;
-    if (ref.playlistId && ref.playlistId !== this.activeCandidate.playlistId) return;
-    if (this.shouldIgnoreEndedTrack(ref)) return;
+  handleTrackEnded(): void {
+    if (!this.activeProgram || !this.activeTrack) return;
+
+    this.activeTrack = null;
+    this.clearTrackCompletionTimer();
 
     const completedProgram = this.activeProgram;
-    const programDelayMs = Math.max(0, completedProgram.program.delaySeconds * 1000);
-
-    this.activeCandidate = null;
-    this.clearPendingTimer();
-
+    const delayMs = Math.max(0, completedProgram.program.delaySeconds * 1000);
     const scheduleNext = () => {
       void this.playNextCandidate(completedProgram.program, completedProgram.key);
     };
 
-    if (programDelayMs <= 0) {
+    if (delayMs <= 0) {
       scheduleNext();
       return;
     }
 
     this.pendingProgramKey = completedProgram.key;
-    this.pendingDelayMs = programDelayMs;
+    this.pendingDelayMs = delayMs;
     this.pendingTimer = this.deps.timers.setTimeout(() => {
       this.pendingTimer = null;
       this.pendingProgramKey = null;
       this.pendingDelayMs = null;
       scheduleNext();
-    }, programDelayMs);
+    }, delayMs);
   }
 
   async stop(): Promise<void> {
     await this.stopActivePlayback();
     this.clearPendingTimer();
+    this.clearTrackCompletionTimer();
     this.activeProgram = null;
-    this.ignoredEndedTrack = null;
     this.lastError = null;
   }
 
-  private ignoredEndedTrack: IgnoredEndedTrack | null = null;
+  private async stopActivePlayback(): Promise<void> {
+    const activeTrack = this.activeTrack;
+    this.activeTrack = null;
 
-  private async stopActivePlayback(): Promise<CandidateIdentity | null> {
-    const activeCandidate = this.activeCandidate;
-    this.activeCandidate = null;
-
-    if (!activeCandidate) return null;
+    if (!activeTrack) return;
     try {
-      if (activeCandidate.playlist.stopSound) {
-        await activeCandidate.playlist.stopSound(activeCandidate.sound);
-      } else {
-        await activeCandidate.playlist.stopAll?.();
-      }
+      await activeTrack.handle.stop();
     } catch {
       this.lastError = "Failed to stop active music track cleanly.";
     }
-    return {
-      playlistId: activeCandidate.playlistId,
-      playlistUuid: activeCandidate.playlistUuid,
-      soundId: activeCandidate.soundId,
-    };
   }
 
   private clearPendingTimer(): void {
@@ -280,44 +185,11 @@ export class SoundscapeMusicRuntime {
     this.pendingDelayMs = null;
   }
 
-  private shouldIgnoreEndedTrack(ref: SoundscapeEndedTrackRef): boolean {
-    if (!this.ignoredEndedTrack) return false;
-
-    const activeCandidateKey = this.activeCandidate ? createCandidateKey(this.activeCandidate) : null;
-    if (activeCandidateKey !== this.ignoredEndedTrack.key) {
-      this.ignoredEndedTrack = null;
-      return false;
+  private clearTrackCompletionTimer(): void {
+    if (this.trackCompletionTimer !== null) {
+      this.deps.timers.clearTimeout(this.trackCompletionTimer);
     }
-
-    const refKey = createEndedTrackKey(ref);
-    if (refKey !== this.ignoredEndedTrack.key) return false;
-    if (this.deps.now() > this.ignoredEndedTrack.ignoreUntil) {
-      this.ignoredEndedTrack = null;
-      return false;
-    }
-
-    this.ignoredEndedTrack = null;
-    return true;
-  }
-
-  private primeIgnoredStaleEndEvent(stoppedCandidate: CandidateIdentity | null): void {
-    if (!stoppedCandidate || !this.activeCandidate) {
-      this.ignoredEndedTrack = null;
-      return;
-    }
-
-    const stoppedKey = createCandidateKey(stoppedCandidate);
-    const activeKey = createCandidateKey(this.activeCandidate);
-    if (stoppedKey !== activeKey) {
-      this.ignoredEndedTrack = null;
-      return;
-    }
-
-    // Ignore one immediate stop echo when a program switch restarts the same track.
-    this.ignoredEndedTrack = {
-      key: activeKey,
-      ignoreUntil: this.deps.now() + PROGRAM_SWITCH_STALE_END_GRACE_MS,
-    };
+    this.trackCompletionTimer = null;
   }
 
   private pickCandidate(
@@ -344,47 +216,44 @@ export class SoundscapeMusicRuntime {
   private async playNextCandidate(program: SoundscapeMusicProgram, programKey: string): Promise<void> {
     if (this.activeProgram?.key !== programKey) return;
 
-    const candidates = await resolveMusicTrackCandidates(program, this.deps.getPlaylistByUuid);
+    const candidates = await resolveMusicTrackCandidates(program, this.deps.resolveAudioPath);
     if (candidates.length === 0) {
-      this.lastError = `No valid playlist tracks could be resolved for music program "${program.name}".`;
-      this.activeCandidate = null;
+      this.lastError = `No valid audio files could be resolved for music program "${program.name}".`;
+      this.activeTrack = null;
       return;
     }
 
     const candidate = this.pickCandidate(programKey, program, candidates);
-    this.lastError = null;
 
     try {
-      await candidate.sound.load?.();
-      if (!candidate.playlist.playSound) {
-        this.lastError = `Playlist "${candidate.playlistName}" cannot start playback on this client.`;
-        this.activeCandidate = null;
+      const started = await candidate.handle.play({ loop: false });
+      if (!started) {
+        this.lastError = `Audio file "${candidate.label}" cannot start playback on this client.`;
+        this.activeTrack = null;
         return;
       }
-      await candidate.playlist.playSound(candidate.sound);
-      candidate.sound.sync?.();
-      this.activeCandidate = candidate;
+
+      this.activeTrack = {
+        path: candidate.path,
+        label: candidate.label,
+        handle: candidate.handle,
+      };
+      this.lastError = null;
+
+      const durationMs = Math.max(0, Math.round(candidate.durationSeconds * 1000));
+      if (durationMs > 0) {
+        this.trackCompletionTimer = this.deps.timers.setTimeout(() => {
+          this.trackCompletionTimer = null;
+          this.handleTrackEnded();
+        }, durationMs);
+      }
     } catch {
-      this.lastError = `Failed to start track "${candidate.soundName}".`;
-      this.activeCandidate = null;
+      this.lastError = `Failed to start track "${candidate.label}".`;
+      this.activeTrack = null;
     }
   }
 }
 
 export const __soundscapeMusicRuntimeInternals = {
-  PROGRAM_SWITCH_STALE_END_GRACE_MS,
   createProgramKey,
-  createCandidateKey,
-  createEndedTrackKey,
-  defaultGetPlaylistByUuid,
-  sortPlaylistSounds,
 };
-
-function createCandidateKey(candidate: CandidateIdentity): string {
-  return `${candidate.playlistUuid}:${candidate.playlistId}:${candidate.soundId}`;
-}
-
-function createEndedTrackKey(ref: SoundscapeEndedTrackRef): string | null {
-  if (!ref.playlistUuid || !ref.playlistId) return null;
-  return `${ref.playlistUuid}:${ref.playlistId}:${ref.soundId}`;
-}

--- a/src/soundscapes/soundscape-normalization.test.ts
+++ b/src/soundscapes/soundscape-normalization.test.ts
@@ -11,7 +11,7 @@ import {
 describe("soundscape normalization", () => {
   it("creates an empty snapshot fallback", () => {
     expect(createEmptySoundscapeLibrarySnapshot()).toMatchObject({
-      formatVersion: 1,
+      formatVersion: 2,
       profiles: {},
     });
   });
@@ -23,7 +23,7 @@ describe("soundscape normalization", () => {
           name: "Forest",
           musicPrograms: {
             calm: {
-              playlistUuids: ["Playlist.one", "Playlist.one", 42],
+              audioPaths: ["sounds/one.ogg", "sounds/one.ogg", 42],
               selectionMode: "weird",
               delaySeconds: -5,
             },
@@ -31,14 +31,14 @@ describe("soundscape normalization", () => {
           ambienceLayers: {
             birds: {
               mode: "random",
-              soundUuids: ["PlaylistSound.one", "", "PlaylistSound.one"],
+              audioPaths: ["sounds/wind.ogg", "", "sounds/wind.ogg"],
               minDelaySeconds: 8,
               maxDelaySeconds: 2,
             },
           },
           soundMoments: {
             sting: {
-              soundUuids: ["PlaylistSound.sting"],
+              audioPaths: ["sounds/sting.ogg"],
               selectionMode: "weird",
             },
           },
@@ -57,12 +57,12 @@ describe("soundscape normalization", () => {
     });
 
     expect(snapshot.profiles.forest?.musicPrograms.calm).toMatchObject({
-      playlistUuids: ["Playlist.one"],
+      audioPaths: ["sounds/one.ogg"],
       selectionMode: "sequential",
       delaySeconds: 0,
     });
     expect(snapshot.profiles.forest?.ambienceLayers.birds).toMatchObject({
-      soundUuids: ["PlaylistSound.one"],
+      audioPaths: ["sounds/wind.ogg"],
       minDelaySeconds: 8,
       maxDelaySeconds: 8,
     });
@@ -86,7 +86,7 @@ describe("soundscape normalization", () => {
             calm: {
               id: "calm",
               name: "Calm",
-              playlistUuids: ["Playlist.calm"],
+              audioPaths: ["music/calm.ogg"],
               selectionMode: "sequential",
               delaySeconds: 0,
             },
@@ -96,7 +96,7 @@ describe("soundscape normalization", () => {
               id: "birds",
               name: "Birds",
               mode: "loop",
-              soundUuids: ["PlaylistSound.birds"],
+              audioPaths: ["ambience/birds.ogg"],
               minDelaySeconds: 0,
               maxDelaySeconds: 0,
             },

--- a/src/soundscapes/soundscape-normalization.ts
+++ b/src/soundscapes/soundscape-normalization.ts
@@ -72,7 +72,7 @@ export function normalizeSoundscapeMusicProgram(raw: unknown, fallbackId = "musi
   return {
     id: sanitizeString(parsed.id) ?? fallbackId,
     name: sanitizeString(parsed.name) ?? "Untitled Music Program",
-    playlistUuids: uniqueStrings(parsed.playlistUuids),
+    audioPaths: uniqueStrings(parsed.audioPaths),
     selectionMode: normalizeSoundscapeSelectionMode(parsed.selectionMode),
     delaySeconds: normalizeNonNegativeNumber(parsed.delaySeconds, 0),
   };
@@ -86,7 +86,7 @@ export function normalizeSoundscapeAmbienceLayer(raw: unknown, fallbackId = "amb
     id: sanitizeString(parsed.id) ?? fallbackId,
     name: sanitizeString(parsed.name) ?? "Untitled Ambience Layer",
     mode: parsed.mode === "random" ? "random" : "loop",
-    soundUuids: uniqueStrings(parsed.soundUuids),
+    audioPaths: uniqueStrings(parsed.audioPaths),
     minDelaySeconds,
     maxDelaySeconds: Math.max(minDelaySeconds, maxDelayCandidate),
   };
@@ -97,7 +97,7 @@ export function normalizeSoundscapeSoundMoment(raw: unknown, fallbackId = "sound
   return {
     id: sanitizeString(parsed.id) ?? fallbackId,
     name: sanitizeString(parsed.name) ?? "Untitled Sound Moment",
-    soundUuids: uniqueStrings(parsed.soundUuids),
+    audioPaths: uniqueStrings(parsed.audioPaths),
     selectionMode: normalizeSoundscapeMomentMode(parsed.selectionMode),
   };
 }

--- a/src/soundscapes/soundscape-resolver.test.ts
+++ b/src/soundscapes/soundscape-resolver.test.ts
@@ -5,7 +5,7 @@ import type { PersistentSoundscapeLibrarySnapshot } from "./soundscape-types";
 
 function makeLibrary(): PersistentSoundscapeLibrarySnapshot {
   return {
-    formatVersion: 1,
+    formatVersion: 2,
     savedAt: "2026-03-27T00:00:00.000Z",
     profiles: {
       forest: {
@@ -15,14 +15,14 @@ function makeLibrary(): PersistentSoundscapeLibrarySnapshot {
           calm: {
             id: "calm",
             name: "Calm",
-            playlistUuids: ["Playlist.calm"],
+            audioPaths: ["music/calm.ogg"],
             selectionMode: "sequential",
             delaySeconds: 0,
           },
           battle: {
             id: "battle",
             name: "Battle",
-            playlistUuids: ["Playlist.battle"],
+            audioPaths: ["music/battle.ogg"],
             selectionMode: "random",
             delaySeconds: 5,
           },
@@ -32,7 +32,7 @@ function makeLibrary(): PersistentSoundscapeLibrarySnapshot {
             id: "birds",
             name: "Birds",
             mode: "loop",
-            soundUuids: ["PlaylistSound.birds"],
+            audioPaths: ["ambience/birds.ogg"],
             minDelaySeconds: 0,
             maxDelaySeconds: 0,
           },
@@ -40,7 +40,7 @@ function makeLibrary(): PersistentSoundscapeLibrarySnapshot {
             id: "rain",
             name: "Rain",
             mode: "loop",
-            soundUuids: ["PlaylistSound.rain"],
+            audioPaths: ["ambience/rain.ogg"],
             minDelaySeconds: 0,
             maxDelaySeconds: 0,
           },
@@ -49,7 +49,7 @@ function makeLibrary(): PersistentSoundscapeLibrarySnapshot {
           sting: {
             id: "sting",
             name: "Sting",
-            soundUuids: ["PlaylistSound.sting"],
+            audioPaths: ["moments/sting.ogg"],
             selectionMode: "single",
           },
         },

--- a/src/soundscapes/soundscape-studio-app.tsx
+++ b/src/soundscapes/soundscape-studio-app.tsx
@@ -208,9 +208,7 @@ function SoundscapeStudioView(): JSX.Element {
     setStatus("Saving soundscape studio changes...");
 
     try {
-      const validation = await validateSoundscapeStudioData(library, worldDefaultProfileId, sceneAssignments, {
-        knownPlaylistUuids: playlists.map((playlist) => playlist.uuid),
-      });
+      const validation = await validateSoundscapeStudioData(library, worldDefaultProfileId, sceneAssignments);
 
       setMessages(validation.messages);
       if (!validation.isValid) {
@@ -416,11 +414,11 @@ function SoundscapeStudioView(): JSX.Element {
                             ...selectedProfile,
                             musicPrograms: {
                               ...selectedProfile.musicPrograms,
-                              [program.id]: { ...program, playlistUuids: parseUuidText(event.target.value) },
+                              [program.id]: { ...program, audioPaths: parseUuidText(event.target.value) },
                             },
                           })}
                           rows={4}
-                          value={stringifyUuidText(program.playlistUuids)}
+                          value={stringifyUuidText(program.audioPaths)}
                         />
                       </LabeledField>
                     </EntityCard>
@@ -545,11 +543,11 @@ function SoundscapeStudioView(): JSX.Element {
                             ...selectedProfile,
                             ambienceLayers: {
                               ...selectedProfile.ambienceLayers,
-                              [layer.id]: { ...layer, soundUuids: parseUuidText(event.target.value) },
+                              [layer.id]: { ...layer, audioPaths: parseUuidText(event.target.value) },
                             },
                           })}
                           rows={4}
-                          value={stringifyUuidText(layer.soundUuids)}
+                          value={stringifyUuidText(layer.audioPaths)}
                         />
                       </LabeledField>
                     </EntityCard>
@@ -630,11 +628,11 @@ function SoundscapeStudioView(): JSX.Element {
                             ...selectedProfile,
                             soundMoments: {
                               ...selectedProfile.soundMoments,
-                              [moment.id]: { ...moment, soundUuids: parseUuidText(event.target.value) },
+                              [moment.id]: { ...moment, audioPaths: parseUuidText(event.target.value) },
                             },
                           })}
                           rows={4}
-                          value={stringifyUuidText(moment.soundUuids)}
+                          value={stringifyUuidText(moment.audioPaths)}
                         />
                       </LabeledField>
                     </EntityCard>

--- a/src/soundscapes/soundscape-studio-helpers.test.ts
+++ b/src/soundscapes/soundscape-studio-helpers.test.ts
@@ -16,22 +16,23 @@ import {
   validateSoundscapeStudioData,
 } from "./soundscape-studio-helpers";
 
-const { fromUuidMock } = vi.hoisted(() => ({
-  fromUuidMock: vi.fn(),
+const { isAudioPathResolvableMock } = vi.hoisted(() => ({
+  isAudioPathResolvableMock: vi.fn(),
+}));
+
+vi.mock("./soundscape-audio-playback", () => ({
+  isAudioPathResolvable: isAudioPathResolvableMock,
 }));
 
 vi.mock("../types", () => ({
-  fromUuid: fromUuidMock,
   getGame: vi.fn(() => ({
-    playlists: [
-      { id: "playlist-1", name: "Town Themes", uuid: "Playlist.playlist-1" },
-    ],
+    playlists: [],
   })),
 }));
 
 function makeSnapshot(): PersistentSoundscapeLibrarySnapshot {
   return {
-    formatVersion: 1,
+    formatVersion: 2,
     savedAt: "2026-03-27T00:00:00.000Z",
     profiles: {},
   };
@@ -40,7 +41,7 @@ function makeSnapshot(): PersistentSoundscapeLibrarySnapshot {
 describe("soundscape studio helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    fromUuidMock.mockResolvedValue({ id: "doc-1" });
+    isAudioPathResolvableMock.mockResolvedValue(true);
   });
 
   it("creates and duplicates profiles with base rules and unique ids", () => {
@@ -54,10 +55,10 @@ describe("soundscape studio helpers", () => {
     expect(duplicate.rules).toEqual(profile.rules);
   });
 
-  it("creates child entities with stable ids", () => {
-    expect(createSoundscapeMusicProgram([]).id).toBe("new-music-program");
-    expect(createSoundscapeAmbienceLayer([]).id).toBe("new-ambience-layer");
-    expect(createSoundscapeSoundMoment([]).id).toBe("new-sound-moment");
+  it("creates child entities with stable ids and audio path arrays", () => {
+    expect(createSoundscapeMusicProgram([])).toMatchObject({ id: "new-music-program", audioPaths: [] });
+    expect(createSoundscapeAmbienceLayer([])).toMatchObject({ id: "new-ambience-layer", audioPaths: [] });
+    expect(createSoundscapeSoundMoment([])).toMatchObject({ id: "new-sound-moment", audioPaths: [] });
     expect(createSoundscapeRule([]).id).toBe("soundscape-rule");
   });
 
@@ -105,32 +106,30 @@ describe("soundscape studio helpers", () => {
 
   it("accepts a valid authored soundscape payload", async () => {
     const profile = createSoundscapeProfile([]);
-    profile.musicPrograms["score"] = {
+    profile.musicPrograms.score = {
       id: "score",
       name: "Town Music",
-      playlistUuids: ["Playlist.playlist-1"],
+      audioPaths: ["music/town.ogg"],
       selectionMode: "random",
       delaySeconds: 12,
     };
-    profile.ambienceLayers["wind"] = {
+    profile.ambienceLayers.wind = {
       id: "wind",
       name: "Cold Wind",
       mode: "random",
-      soundUuids: ["PlaylistSound.wind"],
+      audioPaths: ["ambience/wind.ogg"],
       minDelaySeconds: 5,
       maxDelaySeconds: 15,
     };
-    profile.soundMoments["stinger"] = {
+    profile.soundMoments.stinger = {
       id: "stinger",
       name: "Door Slam",
-      soundUuids: ["PlaylistSound.stinger"],
+      audioPaths: ["moments/stinger.ogg"],
       selectionMode: "single",
     };
     profile.rules = [
       { id: "base", trigger: { type: "base" }, musicProgramId: "score", ambienceLayerIds: ["wind"] },
       { id: "combat", trigger: { type: "combat" }, musicProgramId: null },
-      { id: "night", trigger: { type: "timeOfDay", timeOfDay: "night" }, ambienceLayerIds: ["wind"] },
-      { id: "storm", trigger: { type: "weather", weatherKeys: ["storm"] }, ambienceLayerIds: null },
     ];
 
     const snapshot = replaceProfileInLibrary(makeSnapshot(), profile);
@@ -149,7 +148,7 @@ describe("soundscape studio helpers", () => {
     directProfile.musicPrograms["direct-score"] = {
       id: "direct-score",
       name: "Direct Score",
-      playlistUuids: ["Playlist.playlist-1"],
+      audioPaths: ["music/direct.ogg"],
       selectionMode: "sequential",
       delaySeconds: 0,
     };
@@ -159,7 +158,7 @@ describe("soundscape studio helpers", () => {
     worldProfile.musicPrograms["world-score"] = {
       id: "world-score",
       name: "World Score",
-      playlistUuids: ["Playlist.playlist-1"],
+      audioPaths: ["music/world.ogg"],
       selectionMode: "sequential",
       delaySeconds: 0,
     };
@@ -195,55 +194,49 @@ describe("soundscape studio helpers", () => {
     })?.profileId).toBe(worldProfile.id);
   });
 
-  it("reports malformed triggers, impossible timing, and missing references", async () => {
+  it("reports malformed triggers, impossible timing, and missing audio paths", async () => {
     const profile = createSoundscapeProfile([]);
-    profile.musicPrograms["score"] = {
+    profile.musicPrograms.score = {
       id: "score",
       name: "Broken Music",
-      playlistUuids: ["Playlist.missing"],
+      audioPaths: ["music/missing.ogg"],
       selectionMode: "sequential",
       delaySeconds: -2,
     };
-    profile.ambienceLayers["wind"] = {
+    profile.ambienceLayers.wind = {
       id: "wind",
       name: "",
       mode: "random",
-      soundUuids: ["PlaylistSound.missing"],
+      audioPaths: ["ambience/missing.ogg"],
       minDelaySeconds: 12,
       maxDelaySeconds: 2,
     };
-    profile.soundMoments["stinger"] = {
+    profile.soundMoments.stinger = {
       id: "stinger",
       name: "",
-      soundUuids: [],
+      audioPaths: [],
       selectionMode: "random",
     };
     profile.rules = [
-      { id: "base", trigger: { type: "base" } },
-      { id: "base-2", trigger: { type: "base" }, musicProgramId: "ghost" },
-      { id: "storm-1", trigger: { type: "weather", weatherKeys: [] }, ambienceLayerIds: ["ghost-layer"] },
-      { id: "storm-2", trigger: { type: "weather", weatherKeys: [] }, ambienceLayerIds: ["ghost-layer"] },
+      { id: "combat-a", trigger: { type: "combat" }, musicProgramId: "missing-program" },
+      { id: "combat-b", trigger: { type: "combat" }, ambienceLayerIds: ["missing-layer"] },
+      { id: "weather", trigger: { type: "weather", weatherKeys: [] }, musicProgramId: "score" },
     ];
 
-    fromUuidMock.mockResolvedValue(null);
-
     const snapshot = replaceProfileInLibrary(makeSnapshot(), profile);
-    const result = await validateSoundscapeStudioData(snapshot, "missing-default", {
-      sceneA: { profileId: "missing-scene-profile" },
+    isAudioPathResolvableMock.mockResolvedValue(false);
+
+    const result = await validateSoundscapeStudioData(snapshot, "missing-world", {
+      sceneA: { profileId: "missing-profile" },
     });
 
     expect(result.isValid).toBe(false);
     expect(result.messages).toEqual(expect.arrayContaining([
       expect.objectContaining({ path: "worldDefaultProfileId" }),
       expect.objectContaining({ path: "sceneAssignments.sceneA.profileId" }),
-      expect.objectContaining({ path: "rules", message: "Only one base rule is allowed per soundscape." }),
-      expect.objectContaining({ path: "profiles.new-soundscape.rules.0", message: "Trigger rules must override music, ambience, or both." }),
-      expect.objectContaining({ path: "profiles.new-soundscape.rules.1.musicProgramId" }),
-      expect.objectContaining({ path: "profiles.new-soundscape.rules.2", message: "Weather rules need at least one weather key." }),
-      expect.objectContaining({ path: "profiles.new-soundscape.rules.3", message: "Duplicate trigger rule detected for \"weather:\"." }),
-      expect.objectContaining({ path: "profiles.new-soundscape.musicPrograms.score.delaySeconds" }),
-      expect.objectContaining({ path: "profiles.new-soundscape.ambienceLayers.wind", message: "Ambience max delay must be greater than or equal to min delay." }),
-      expect.objectContaining({ path: "profiles.new-soundscape.soundMoments.stinger.soundUuids" }),
+      expect.objectContaining({ path: "profiles.new-soundscape.rules.0.musicProgramId" }),
+      expect.objectContaining({ path: "profiles.new-soundscape.musicPrograms.score.audioPaths" }),
+      expect.objectContaining({ path: "profiles.new-soundscape.soundMoments.stinger.audioPaths" }),
     ]));
   });
 });

--- a/src/soundscapes/soundscape-studio-helpers.ts
+++ b/src/soundscapes/soundscape-studio-helpers.ts
@@ -1,4 +1,5 @@
-import { fromUuid, getGame } from "../types";
+import { getGame } from "../types";
+import { isAudioPathResolvable } from "./soundscape-audio-playback";
 import {
   type PersistentSoundscapeLibrarySnapshot,
   type ResolvedSoundscapeState,
@@ -25,8 +26,7 @@ export interface SoundscapeStudioValidationResult {
 }
 
 interface SoundscapeStudioValidationOptions {
-  resolveUuid?: (uuid: string) => Promise<boolean>;
-  knownPlaylistUuids?: Iterable<string>;
+  resolveAudioPath?: (path: string) => Promise<boolean>;
 }
 
 function slugifySegment(value: string, fallback: string): string {
@@ -132,7 +132,7 @@ export function createSoundscapeMusicProgram(existingIds: Iterable<string>, name
   return {
     id,
     name,
-    playlistUuids: [],
+    audioPaths: [],
     selectionMode: "sequential",
     delaySeconds: 0,
   };
@@ -144,7 +144,7 @@ export function createSoundscapeAmbienceLayer(existingIds: Iterable<string>, nam
     id,
     name,
     mode: "loop",
-    soundUuids: [],
+    audioPaths: [],
     minDelaySeconds: 0,
     maxDelaySeconds: 0,
   };
@@ -155,7 +155,7 @@ export function createSoundscapeSoundMoment(existingIds: Iterable<string>, name 
   return {
     id,
     name,
-    soundUuids: [],
+    audioPaths: [],
     selectionMode: "single",
   };
 }
@@ -256,8 +256,7 @@ export async function validateSoundscapeStudioData(
   options: SoundscapeStudioValidationOptions = {},
 ): Promise<SoundscapeStudioValidationResult> {
   const messages: SoundscapeStudioValidationMessage[] = [];
-  const knownPlaylistUuids = new Set(options.knownPlaylistUuids ?? getKnownPlaylistUuidSet());
-  const resolveUuid = options.resolveUuid ?? (async (uuid: string) => (await fromUuid(uuid)) !== null);
+  const resolveAudioPath = options.resolveAudioPath ?? isAudioPathResolvable;
   const profiles = Object.values(snapshot.profiles);
   const profileIds = new Set(profiles.map((profile) => profile.id));
 
@@ -278,11 +277,11 @@ export async function validateSoundscapeStudioData(
     }
   }
 
-  const uniqueAssetUuids = new Map<string, string[]>();
-  const queueAssetCheck = (uuid: string, path: string): void => {
-    const paths = uniqueAssetUuids.get(uuid) ?? [];
+  const uniqueAudioPaths = new Map<string, string[]>();
+  const queueAssetCheck = (audioPath: string, path: string): void => {
+    const paths = uniqueAudioPaths.get(audioPath) ?? [];
     paths.push(path);
-    uniqueAssetUuids.set(uuid, paths);
+    uniqueAudioPaths.set(audioPath, paths);
   };
 
   for (const profile of profiles) {
@@ -381,17 +380,15 @@ export async function validateSoundscapeStudioData(
           message: "Music delay cannot be negative.",
         });
       }
-      if (program.playlistUuids.length === 0) {
+      if (program.audioPaths.length === 0) {
         messages.push({
           profileId: profile.id,
-          path: `${prefix}.playlistUuids`,
-          message: "Music programs need at least one playlist UUID.",
+          path: `${prefix}.audioPaths`,
+          message: "Music programs need at least one audio path.",
         });
       }
-      for (const playlistUuid of program.playlistUuids) {
-        if (!knownPlaylistUuids.has(playlistUuid)) {
-          queueAssetCheck(playlistUuid, `${prefix}.playlistUuids`);
-        }
+      for (const audioPath of program.audioPaths) {
+        queueAssetCheck(audioPath, `${prefix}.audioPaths`);
       }
     }
 
@@ -418,15 +415,15 @@ export async function validateSoundscapeStudioData(
           message: "Ambience max delay must be greater than or equal to min delay.",
         });
       }
-      if (layer.soundUuids.length === 0) {
+      if (layer.audioPaths.length === 0) {
         messages.push({
           profileId: profile.id,
-          path: `${prefix}.soundUuids`,
-          message: "Ambience layers need at least one sound UUID.",
+          path: `${prefix}.audioPaths`,
+          message: "Ambience layers need at least one audio path.",
         });
       }
-      for (const soundUuid of layer.soundUuids) {
-        queueAssetCheck(soundUuid, `${prefix}.soundUuids`);
+      for (const audioPath of layer.audioPaths) {
+        queueAssetCheck(audioPath, `${prefix}.audioPaths`);
       }
     }
 
@@ -439,27 +436,27 @@ export async function validateSoundscapeStudioData(
           message: "Sound moments need a name.",
         });
       }
-      if (moment.soundUuids.length === 0) {
+      if (moment.audioPaths.length === 0) {
         messages.push({
           profileId: profile.id,
-          path: `${prefix}.soundUuids`,
-          message: "Sound moments need at least one sound UUID.",
+          path: `${prefix}.audioPaths`,
+          message: "Sound moments need at least one audio path.",
         });
       }
-      for (const soundUuid of moment.soundUuids) {
-        queueAssetCheck(soundUuid, `${prefix}.soundUuids`);
+      for (const audioPath of moment.audioPaths) {
+        queueAssetCheck(audioPath, `${prefix}.audioPaths`);
       }
     }
   }
 
-  for (const [uuid, paths] of uniqueAssetUuids.entries()) {
-    const exists = await resolveUuid(uuid);
+  for (const [audioPath, paths] of uniqueAudioPaths.entries()) {
+    const exists = await resolveAudioPath(audioPath);
     if (exists) continue;
 
     for (const path of paths) {
       messages.push({
         path,
-        message: `Referenced UUID "${uuid}" could not be resolved.`,
+        message: `Referenced audio path "${audioPath}" could not be resolved.`,
       });
     }
   }

--- a/src/soundscapes/soundscape-types.ts
+++ b/src/soundscapes/soundscape-types.ts
@@ -1,6 +1,6 @@
-export const SOUNDSCAPE_LIBRARY_FORMAT_VERSION = 1;
+export const SOUNDSCAPE_LIBRARY_FORMAT_VERSION = 2;
 
-export type SoundscapeUuid = string;
+export type SoundscapeAudioPath = string;
 export type SoundscapeSelectionMode = "sequential" | "random";
 export type SoundscapeLayerMode = "loop" | "random";
 export type SoundscapeMomentMode = "single" | "random";
@@ -11,7 +11,7 @@ export type SoundscapeAssignmentSource = "scene" | "worldDefault";
 export interface SoundscapeMusicProgram {
   id: string;
   name: string;
-  playlistUuids: SoundscapeUuid[];
+  audioPaths: SoundscapeAudioPath[];
   selectionMode: SoundscapeSelectionMode;
   delaySeconds: number;
 }
@@ -20,7 +20,7 @@ export interface SoundscapeAmbienceLayer {
   id: string;
   name: string;
   mode: SoundscapeLayerMode;
-  soundUuids: SoundscapeUuid[];
+  audioPaths: SoundscapeAudioPath[];
   minDelaySeconds: number;
   maxDelaySeconds: number;
 }
@@ -28,7 +28,7 @@ export interface SoundscapeAmbienceLayer {
 export interface SoundscapeSoundMoment {
   id: string;
   name: string;
-  soundUuids: SoundscapeUuid[];
+  audioPaths: SoundscapeAudioPath[];
   selectionMode: SoundscapeMomentMode;
 }
 


### PR DESCRIPTION
## Summary
- replace soundscape UUID storage with ordered audio paths and bump the library format to 2
- add a shared direct-audio playback adapter and migrate music, ambience, and moment playback to it
- update soundscape snapshots, helper validation, and focused soundscape tests to the new path-based model

Closes #92

## Verification
- npm run typecheck
- npm run test -- src/soundscapes