### PR TITLE
fix: refresh soundscape audio duration after load

### DIFF
--- a/src/soundscapes/soundscape-ambience-runtime.test.ts
+++ b/src/soundscapes/soundscape-ambience-runtime.test.ts
@@ -215,6 +215,43 @@ describe("soundscape ambience runtime", () => {
     });
   });
 
+  it("uses duration populated during load when scheduling random ambience cleanup", async () => {
+    const timers = createFakeTimers();
+    let durationSeconds = 0;
+    const gust = {
+      path: "ambience/runtime-duration.ogg",
+      get durationSeconds() {
+        return durationSeconds;
+      },
+      load: vi.fn(async (): Promise<void> => {
+        durationSeconds = 2.25;
+      }),
+      play: vi.fn(async (): Promise<boolean> => true),
+      stop: vi.fn(async (): Promise<void> => {}),
+    };
+    const runtime = new SoundscapeAmbienceRuntime({
+      resolveAudioPath: async () => gust,
+      timers: timers.api,
+    });
+
+    await runtime.sync(createResolvedState({
+      ambienceLayers: [{
+        id: "runtime-duration",
+        name: "Runtime Duration",
+        mode: "random",
+        audioPaths: [gust.path],
+        minDelaySeconds: 0,
+        maxDelaySeconds: 0,
+      }],
+    }));
+
+    timers.runNext();
+    await flushAsyncWork();
+
+    expect(timers.handles).toHaveLength(2);
+    expect(timers.handles[1]?.delay).toBe(2250);
+  });
+
   it("plays manual moments using direct audio paths", async () => {
     const sting = createAudioHandle("moments/sting.ogg", 1);
     const runtime = new SoundscapeAmbienceRuntime({

--- a/src/soundscapes/soundscape-audio-playback.test.ts
+++ b/src/soundscapes/soundscape-audio-playback.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveAudioPathPlayback } from "./soundscape-audio-playback";
+
+describe("soundscape audio playback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes duration metadata after load completes", async () => {
+    let duration = 0;
+    const sound = {
+      get duration() {
+        return duration;
+      },
+      load: vi.fn(async (): Promise<void> => {
+        duration = 13.25;
+      }),
+      play: vi.fn(async (): Promise<void> => {}),
+      stop: vi.fn(async (): Promise<void> => {}),
+    };
+
+    vi.stubGlobal("foundry", {
+      audio: {
+        Sound: {
+          create: vi.fn(async () => sound),
+        },
+      },
+    });
+
+    const handle = await resolveAudioPathPlayback("music/runtime.ogg");
+
+    expect(handle).not.toBeNull();
+    expect(handle?.durationSeconds).toBe(0);
+
+    await handle?.load();
+
+    expect(handle?.durationSeconds).toBe(13.25);
+  });
+});

--- a/src/soundscapes/soundscape-audio-playback.ts
+++ b/src/soundscapes/soundscape-audio-playback.ts
@@ -91,7 +91,9 @@ export async function resolveAudioPathPlayback(path: string): Promise<Soundscape
 
   return {
     path: trimmedPath,
-    durationSeconds: normalizeDurationSeconds(sound),
+    get durationSeconds(): number {
+      return normalizeDurationSeconds(sound);
+    },
     async load(): Promise<void> {
       await sound.load?.();
     },

--- a/src/soundscapes/soundscape-music-runtime.test.ts
+++ b/src/soundscapes/soundscape-music-runtime.test.ts
@@ -147,6 +147,38 @@ describe("soundscape music runtime", () => {
     });
   });
 
+  it("uses duration populated during load when scheduling track completion", async () => {
+    const timers = createFakeTimers();
+    let durationSeconds = 0;
+    const track = {
+      path: "music/runtime-duration.ogg",
+      get durationSeconds() {
+        return durationSeconds;
+      },
+      load: vi.fn(async (): Promise<void> => {
+        durationSeconds = 1.5;
+      }),
+      play: vi.fn(async (): Promise<boolean> => true),
+      stop: vi.fn(async (): Promise<void> => {}),
+    };
+    const program: SoundscapeMusicProgram = {
+      id: "runtime-duration",
+      name: "Runtime Duration",
+      audioPaths: [track.path],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    };
+    const runtime = new SoundscapeMusicRuntime({
+      resolveAudioPath: async () => track,
+      timers: timers.api,
+    });
+
+    await runtime.sync(createResolvedState(program));
+
+    expect(timers.handles).toHaveLength(1);
+    expect(timers.handles[0]?.delay).toBe(1500);
+  });
+
   it("uses deterministic random selection without repeating immediately when alternatives exist", async () => {
     const timers = createFakeTimers();
     const handles = [


### PR DESCRIPTION
## Summary
- make soundscape audio handles report duration lazily so post-load metadata is visible to runtimes
- add a regression test for the playback adapter
- cover music and ambience timer scheduling with post-load duration values

## Testing
- npm run test -- src/soundscapes/soundscape-audio-playback.test.ts src/soundscapes/soundscape-music-runtime.test.ts src/soundscapes/soundscape-ambience-runtime.test.ts
- npm run typecheck

Follow-up for #92.