### PR TITLE
test: harden soundscape path validation coverage

### DIFF
--- a/src/soundscapes/soundscape-ambience-runtime.test.ts
+++ b/src/soundscapes/soundscape-ambience-runtime.test.ts
@@ -117,10 +117,14 @@ describe("soundscape ambience runtime", () => {
 
     expect(wind.play).toHaveBeenCalledTimes(1);
     expect(birds.play).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
+    expect(runtime.getSnapshot()).toEqual({
+      activeAmbienceKey: "forest:forest-loop|mist-loop",
       activeLayerIds: ["forest-loop", "mist-loop"],
       loopAudioPaths: ["ambience/birds.ogg", "ambience/wind.ogg"],
       randomLayerIds: [],
+      activeRandomAudioPaths: [],
+      pendingRandomLayerIds: [],
+      lastError: null,
     });
   });
 

--- a/src/soundscapes/soundscape-api.test.ts
+++ b/src/soundscapes/soundscape-api.test.ts
@@ -1,14 +1,49 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getStoredSoundscapeLibrarySnapshotMock = vi.fn(() => ({ profiles: {} }));
+const getStoredSoundscapeLibrarySnapshotMock = vi.fn(() => ({ formatVersion: 2, profiles: {} }));
 const resolveStoredSoundscapeStateMock = vi.fn(() => ({ profileId: "profile-1" }));
-const getSoundscapeAmbienceRuntimeSnapshotMock = vi.fn(() => ({ activeLayerIds: [] }));
-const playStoredSoundscapeMomentMock = vi.fn(async () => ({ played: true }));
+const getSoundscapeAmbienceRuntimeSnapshotMock = vi.fn(() => ({
+  activeAmbienceKey: "forest:wind",
+  activeLayerIds: ["wind"],
+  loopAudioPaths: ["ambience/wind.ogg"],
+  randomLayerIds: ["gusts"],
+  activeRandomAudioPaths: ["ambience/gust-a.ogg"],
+  pendingRandomLayerIds: ["gusts"],
+  lastError: null,
+}));
+const playStoredSoundscapeMomentMock = vi.fn(async () => ({
+  momentId: "sting",
+  audioPath: "moments/sting.ogg",
+  played: true,
+  error: null,
+}));
 const stopStoredSoundscapeAmbienceMock = vi.fn(async () => {});
-const syncStoredSoundscapeAmbienceMock = vi.fn(async () => ({ activeLayerIds: [] }));
-const getSoundscapeMusicRuntimeSnapshotMock = vi.fn(() => ({ activeProgramId: "program-1" }));
+const syncStoredSoundscapeAmbienceMock = vi.fn(async () => ({
+  activeAmbienceKey: "forest:wind",
+  activeLayerIds: ["wind"],
+  loopAudioPaths: ["ambience/wind.ogg"],
+  randomLayerIds: ["gusts"],
+  activeRandomAudioPaths: ["ambience/gust-a.ogg"],
+  pendingRandomLayerIds: ["gusts"],
+  lastError: null,
+}));
+const getSoundscapeMusicRuntimeSnapshotMock = vi.fn(() => ({
+  activeProgramKey: "forest:program-1",
+  activeProgramId: "program-1",
+  activeAudioPath: "music/forest.ogg",
+  pendingProgramKey: null,
+  pendingDelayMs: 2500,
+  lastError: null,
+}));
 const stopStoredSoundscapeMusicMock = vi.fn(async () => {});
-const syncStoredSoundscapeMusicMock = vi.fn(async () => ({ activeProgramId: "program-1" }));
+const syncStoredSoundscapeMusicMock = vi.fn(async () => ({
+  activeProgramKey: "forest:program-1",
+  activeProgramId: "program-1",
+  activeAudioPath: "music/forest.ogg",
+  pendingProgramKey: null,
+  pendingDelayMs: 2500,
+  lastError: null,
+}));
 const openSoundscapeStudioMock = vi.fn();
 const openSoundscapeLiveControlsMock = vi.fn();
 
@@ -47,17 +82,52 @@ describe("soundscape api", () => {
     const mod = await import("./soundscape-api");
     const api = mod.buildSoundscapeApi();
 
-    api.soundscapes.getLibrary();
-    api.soundscapes.resolve("scene-1", { inCombat: true });
+    expect(api.soundscapes.getLibrary()).toEqual({ formatVersion: 2, profiles: {} });
+    expect(api.soundscapes.resolve("scene-1", { inCombat: true })).toEqual({ profileId: "profile-1" });
     api.soundscapes.openStudio();
     api.soundscapes.openLiveControls();
-    await api.soundscapes.syncMusic();
+    await expect(api.soundscapes.syncMusic()).resolves.toEqual({
+      activeProgramKey: "forest:program-1",
+      activeProgramId: "program-1",
+      activeAudioPath: "music/forest.ogg",
+      pendingProgramKey: null,
+      pendingDelayMs: 2500,
+      lastError: null,
+    });
     await api.soundscapes.stopMusic();
-    api.soundscapes.getMusicState();
-    await api.soundscapes.syncAmbience();
+    expect(api.soundscapes.getMusicState()).toEqual({
+      activeProgramKey: "forest:program-1",
+      activeProgramId: "program-1",
+      activeAudioPath: "music/forest.ogg",
+      pendingProgramKey: null,
+      pendingDelayMs: 2500,
+      lastError: null,
+    });
+    await expect(api.soundscapes.syncAmbience()).resolves.toEqual({
+      activeAmbienceKey: "forest:wind",
+      activeLayerIds: ["wind"],
+      loopAudioPaths: ["ambience/wind.ogg"],
+      randomLayerIds: ["gusts"],
+      activeRandomAudioPaths: ["ambience/gust-a.ogg"],
+      pendingRandomLayerIds: ["gusts"],
+      lastError: null,
+    });
     await api.soundscapes.stopAmbience();
-    api.soundscapes.getAmbienceState();
-    await api.soundscapes.playMoment("sting");
+    expect(api.soundscapes.getAmbienceState()).toEqual({
+      activeAmbienceKey: "forest:wind",
+      activeLayerIds: ["wind"],
+      loopAudioPaths: ["ambience/wind.ogg"],
+      randomLayerIds: ["gusts"],
+      activeRandomAudioPaths: ["ambience/gust-a.ogg"],
+      pendingRandomLayerIds: ["gusts"],
+      lastError: null,
+    });
+    await expect(api.soundscapes.playMoment("sting")).resolves.toEqual({
+      momentId: "sting",
+      audioPath: "moments/sting.ogg",
+      played: true,
+      error: null,
+    });
 
     expect(getStoredSoundscapeLibrarySnapshotMock).toHaveBeenCalledTimes(1);
     expect(resolveStoredSoundscapeStateMock).toHaveBeenCalledWith("scene-1", { inCombat: true });

--- a/src/soundscapes/soundscape-live-controls-app.test.tsx
+++ b/src/soundscapes/soundscape-live-controls-app.test.tsx
@@ -1,3 +1,4 @@
+import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -12,6 +13,14 @@ const {
   foundryReactUnmountMock,
   ensureNativeWindowResizeHandleMock,
   ensureWindowSizeConstraintsMock,
+  getSoundscapeSceneByIdMock,
+  resolveStoredSoundscapeStateMock,
+  getSoundscapeAmbienceRuntimeSnapshotMock,
+  playStoredSoundscapeMomentMock,
+  getSoundscapeMusicRuntimeSnapshotMock,
+  openSoundscapeStudioMock,
+  listSoundscapeScenesMock,
+  getSoundscapeTriggerContextMock,
 } = vi.hoisted(() => ({
   logWarnMock: vi.fn(),
   logDebugMock: vi.fn(),
@@ -24,6 +33,35 @@ const {
   foundryReactUnmountMock: vi.fn(),
   ensureNativeWindowResizeHandleMock: vi.fn(),
   ensureWindowSizeConstraintsMock: vi.fn(),
+  getSoundscapeSceneByIdMock: vi.fn(() => ({ id: "scene-1" })),
+  resolveStoredSoundscapeStateMock: vi.fn(() => null),
+  getSoundscapeAmbienceRuntimeSnapshotMock: vi.fn(() => ({
+    activeLayerIds: [],
+    loopAudioPaths: [],
+    activeRandomAudioPaths: [],
+    pendingRandomLayerIds: [],
+    lastError: null,
+  })),
+  playStoredSoundscapeMomentMock: vi.fn(async () => ({
+    played: true,
+    error: null,
+    audioPath: "moments/sting.ogg",
+    momentId: "sting",
+  })),
+  getSoundscapeMusicRuntimeSnapshotMock: vi.fn(() => ({
+    activeProgramId: null,
+    activeAudioPath: null,
+    pendingDelayMs: null,
+    lastError: null,
+  })),
+  openSoundscapeStudioMock: vi.fn(),
+  listSoundscapeScenesMock: vi.fn(() => [{ id: "scene-1", name: "Active Scene", active: true }]),
+  getSoundscapeTriggerContextMock: vi.fn(() => ({
+    manualPreview: false,
+    inCombat: false,
+    weather: null,
+    timeOfDay: "day",
+  })),
 }));
 
 vi.mock("../logger", () => ({
@@ -58,48 +96,29 @@ vi.mock("../ui/foundry/application-v2/window-size-constraints", () => ({
 }));
 
 vi.mock("./soundscape-accessors", () => ({
-  getSoundscapeSceneById: vi.fn(() => ({ id: "scene-1" })),
-  resolveStoredSoundscapeState: vi.fn(() => null),
+  getSoundscapeSceneById: getSoundscapeSceneByIdMock,
+  resolveStoredSoundscapeState: resolveStoredSoundscapeStateMock,
 }));
 
 vi.mock("./soundscape-ambience-controller", () => ({
-  getSoundscapeAmbienceRuntimeSnapshot: vi.fn(() => ({
-    activeLayerIds: [],
-    pendingRandomLayerIds: [],
-    lastError: null,
-  })),
-  playStoredSoundscapeMoment: vi.fn(async () => ({
-    played: true,
-    error: null,
-    audioPath: "moments/sting.ogg",
-    momentId: "sting",
-  })),
+  getSoundscapeAmbienceRuntimeSnapshot: getSoundscapeAmbienceRuntimeSnapshotMock,
+  playStoredSoundscapeMoment: playStoredSoundscapeMomentMock,
 }));
 
 vi.mock("./soundscape-music-controller", () => ({
-  getSoundscapeMusicRuntimeSnapshot: vi.fn(() => ({
-    activeProgramId: null,
-    activeAudioPath: null,
-    pendingDelayMs: null,
-    lastError: null,
-  })),
+  getSoundscapeMusicRuntimeSnapshot: getSoundscapeMusicRuntimeSnapshotMock,
 }));
 
 vi.mock("./soundscape-studio-app", () => ({
-  openSoundscapeStudio: vi.fn(),
+  openSoundscapeStudio: openSoundscapeStudioMock,
 }));
 
 vi.mock("./soundscape-studio-helpers", () => ({
-  listSoundscapeScenes: vi.fn(() => [{ id: "scene-1", name: "Active Scene", active: true }]),
+  listSoundscapeScenes: listSoundscapeScenesMock,
 }));
 
 vi.mock("./soundscape-trigger-service", () => ({
-  getSoundscapeTriggerContext: vi.fn(() => ({
-    manualPreview: false,
-    inCombat: false,
-    weather: null,
-    timeOfDay: "day",
-  })),
+  getSoundscapeTriggerContext: getSoundscapeTriggerContextMock,
 }));
 
 class FakeElement {
@@ -253,5 +272,71 @@ describe("SoundscapeLiveControlsApp", () => {
     mod.openSoundscapeLiveControls();
 
     expect(warn).toHaveBeenCalledWith("Soundscape Live Controls are only available to GMs.");
+  });
+
+  it("renders path-based runtime snapshot details and moment counts", async () => {
+    const mod = await modPromise;
+    mod.buildSoundscapeLiveControlsAppClass();
+    resolveStoredSoundscapeStateMock.mockReturnValue({
+      profileId: "forest",
+      assignmentSource: "worldDefault",
+      sceneId: "scene-1",
+      context: {
+        manualPreview: false,
+        inCombat: false,
+        weather: null,
+        timeOfDay: "day",
+      },
+      musicProgramId: "calm",
+      musicProgram: {
+        id: "calm",
+        name: "Calm",
+        audioPaths: ["music/live.ogg"],
+        selectionMode: "sequential",
+        delaySeconds: 0,
+      },
+      musicRuleId: "base",
+      ambienceLayerIds: [],
+      ambienceLayers: [],
+      ambienceRuleId: null,
+      soundMoments: [{
+        id: "sting",
+        name: "Sting",
+        audioPaths: ["moments/one.ogg", "moments/two.ogg"],
+        selectionMode: "random",
+      }],
+    } as never);
+    getSoundscapeMusicRuntimeSnapshotMock.mockReturnValue({
+      activeProgramId: "calm",
+      activeAudioPath: "music/live.ogg",
+      pendingDelayMs: 1200,
+      lastError: null,
+    } as never);
+    getSoundscapeAmbienceRuntimeSnapshotMock.mockReturnValue({
+      activeLayerIds: ["wind"],
+      loopAudioPaths: ["ambience/wind.ogg"],
+      activeRandomAudioPaths: ["ambience/gust.ogg"],
+      pendingRandomLayerIds: ["wind"],
+      lastError: null,
+    } as never);
+
+    const AppClass = mod.getSoundscapeLiveControlsAppClass();
+    const app = new (AppClass as unknown as new () => {
+      element: FakeElement | null;
+      _onRender: (_context: Record<string, never>, _options: unknown) => Promise<void>;
+    })();
+    const mount = new FakeElement("div");
+    const root = new FakeElement("section");
+    root.setQueryResult("[data-fth-react-root]", mount);
+    app.element = root;
+
+    await app._onRender({}, {});
+
+    const renderedElement = foundryReactRenderMock.mock.calls.at(-1)?.[1];
+    const markup = renderToStaticMarkup(renderedElement);
+
+    expect(markup).toContain("Audio Path");
+    expect(markup).toContain("music/live.ogg");
+    expect(markup).toContain("sting · 2 sounds");
   });
 });

--- a/src/soundscapes/soundscape-music-runtime.test.ts
+++ b/src/soundscapes/soundscape-music-runtime.test.ts
@@ -123,10 +123,13 @@ describe("soundscape music runtime", () => {
     await runtime.sync(createResolvedState(program));
 
     expect(first.play).toHaveBeenCalledTimes(1);
-    expect(runtime.getSnapshot()).toMatchObject({
+    expect(runtime.getSnapshot()).toEqual({
+      activeProgramKey: "forest:calm",
       activeProgramId: "calm",
       activeAudioPath: "music/town-a.ogg",
+      pendingProgramKey: null,
       pendingDelayMs: null,
+      lastError: null,
     });
 
     timers.runNext();

--- a/src/soundscapes/soundscape-normalization.test.ts
+++ b/src/soundscapes/soundscape-normalization.test.ts
@@ -2,28 +2,31 @@ import { describe, expect, it } from "vitest";
 
 import {
   createEmptySoundscapeLibrarySnapshot,
+  createPersistedSoundscapeLibrarySnapshot,
   normalizeSoundscapeLibrarySnapshot,
   normalizeSoundscapeSceneAssignment,
   normalizeSoundscapeTriggerContext,
   parseStoredSoundscapeLibrarySnapshot,
 } from "./soundscape-normalization";
+import { SOUNDSCAPE_LIBRARY_FORMAT_VERSION } from "./soundscape-types";
 
 describe("soundscape normalization", () => {
   it("creates an empty snapshot fallback", () => {
     expect(createEmptySoundscapeLibrarySnapshot()).toMatchObject({
-      formatVersion: 2,
+      formatVersion: SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
       profiles: {},
     });
   });
 
-  it("normalizes malformed library data to safe defaults", () => {
+  it("normalizes malformed library data to safe defaults while preserving authored path order", () => {
     const snapshot = normalizeSoundscapeLibrarySnapshot({
+      formatVersion: 1,
       profiles: {
         forest: {
           name: "Forest",
           musicPrograms: {
             calm: {
-              audioPaths: ["sounds/one.ogg", "sounds/one.ogg", 42],
+              audioPaths: ["sounds/one.ogg", "sounds/two.ogg", "sounds/one.ogg", 42, "sounds/three.ogg"],
               selectionMode: "weird",
               delaySeconds: -5,
             },
@@ -31,14 +34,14 @@ describe("soundscape normalization", () => {
           ambienceLayers: {
             birds: {
               mode: "random",
-              audioPaths: ["sounds/wind.ogg", "", "sounds/wind.ogg"],
+              audioPaths: ["sounds/wind.ogg", "", "sounds/rain.ogg", "sounds/wind.ogg"],
               minDelaySeconds: 8,
               maxDelaySeconds: 2,
             },
           },
           soundMoments: {
             sting: {
-              audioPaths: ["sounds/sting.ogg"],
+              audioPaths: ["sounds/sting.ogg", "sounds/chime.ogg", "sounds/sting.ogg"],
               selectionMode: "weird",
             },
           },
@@ -56,17 +59,21 @@ describe("soundscape normalization", () => {
       },
     });
 
+    expect(snapshot.formatVersion).toBe(SOUNDSCAPE_LIBRARY_FORMAT_VERSION);
     expect(snapshot.profiles.forest?.musicPrograms.calm).toMatchObject({
-      audioPaths: ["sounds/one.ogg"],
+      audioPaths: ["sounds/one.ogg", "sounds/two.ogg", "sounds/three.ogg"],
       selectionMode: "sequential",
       delaySeconds: 0,
     });
     expect(snapshot.profiles.forest?.ambienceLayers.birds).toMatchObject({
-      audioPaths: ["sounds/wind.ogg"],
+      audioPaths: ["sounds/wind.ogg", "sounds/rain.ogg"],
       minDelaySeconds: 8,
       maxDelaySeconds: 8,
     });
-    expect(snapshot.profiles.forest?.soundMoments.sting?.selectionMode).toBe("single");
+    expect(snapshot.profiles.forest?.soundMoments.sting).toMatchObject({
+      audioPaths: ["sounds/sting.ogg", "sounds/chime.ogg"],
+      selectionMode: "single",
+    });
     expect(snapshot.profiles.forest?.rules[0]?.trigger).toEqual({
       type: "weather",
       weatherKeys: ["rain"],
@@ -75,6 +82,36 @@ describe("soundscape normalization", () => {
       type: "timeOfDay",
       timeOfDay: "day",
     });
+  });
+
+  it("parses stored snapshots only at format version 2", () => {
+    expect(parseStoredSoundscapeLibrarySnapshot({
+      formatVersion: SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
+      savedAt: "2026-03-27T00:00:00.000Z",
+      profiles: {
+        forest: {
+          id: "forest",
+          name: "Forest",
+          musicPrograms: {},
+          ambienceLayers: {},
+          soundMoments: {},
+          rules: [],
+        },
+      },
+    })).toMatchObject({
+      formatVersion: SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
+      profiles: {
+        forest: {
+          id: "forest",
+        },
+      },
+    });
+
+    expect(parseStoredSoundscapeLibrarySnapshot({
+      formatVersion: 1,
+      savedAt: "2026-03-27T00:00:00.000Z",
+      profiles: {},
+    })).toBeNull();
   });
 
   it("drops invalid rule references during normalization", () => {
@@ -156,5 +193,29 @@ describe("soundscape normalization", () => {
       savedAt: "2026-03-27T00:00:00.000Z",
       profiles: {},
     })).toBeNull();
+  });
+
+  it("creates persisted snapshots in format version 2", () => {
+    expect(createPersistedSoundscapeLibrarySnapshot({
+      formatVersion: 1,
+      profiles: {
+        forest: {
+          id: "forest",
+          name: "Forest",
+          musicPrograms: {},
+          ambienceLayers: {},
+          soundMoments: {},
+          rules: [],
+        },
+      },
+    }, "2026-03-28T00:00:00.000Z")).toMatchObject({
+      formatVersion: SOUNDSCAPE_LIBRARY_FORMAT_VERSION,
+      savedAt: "2026-03-28T00:00:00.000Z",
+      profiles: {
+        forest: {
+          id: "forest",
+        },
+      },
+    });
   });
 });

--- a/src/soundscapes/soundscape-studio-helpers.test.ts
+++ b/src/soundscapes/soundscape-studio-helpers.test.ts
@@ -143,6 +143,63 @@ describe("soundscape studio helpers", () => {
     });
   });
 
+  it("validates audio paths by indexed path and only resolves each unique path once", async () => {
+    const profile = createSoundscapeProfile([]);
+    profile.musicPrograms.score = {
+      id: "score",
+      name: "Town Music",
+      audioPaths: ["  ", "shared/audio.ogg", "music/missing.ogg"],
+      selectionMode: "sequential",
+      delaySeconds: 0,
+    };
+    profile.ambienceLayers.wind = {
+      id: "wind",
+      name: "Cold Wind",
+      mode: "loop",
+      audioPaths: ["shared/audio.ogg", "ambience/missing.ogg"],
+      minDelaySeconds: 0,
+      maxDelaySeconds: 0,
+    };
+    profile.soundMoments.stinger = {
+      id: "stinger",
+      name: "Door Slam",
+      audioPaths: ["shared/audio.ogg", " "],
+      selectionMode: "single",
+    };
+    profile.rules = [
+      { id: "base", trigger: { type: "base" }, musicProgramId: "score", ambienceLayerIds: ["wind"] },
+    ];
+
+    const snapshot = replaceProfileInLibrary(makeSnapshot(), profile);
+    isAudioPathResolvableMock.mockImplementation(async (audioPath: string) => audioPath === "shared/audio.ogg");
+
+    const result = await validateSoundscapeStudioData(snapshot, null, {});
+
+    expect(result.isValid).toBe(false);
+    expect(result.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: "profiles.new-soundscape.musicPrograms.score.audioPaths.0",
+        message: "Music program audio paths cannot be blank.",
+      }),
+      expect.objectContaining({
+        path: "profiles.new-soundscape.musicPrograms.score.audioPaths.2",
+        message: 'Selected audio path "music/missing.ogg" could not be loaded by Foundry.',
+      }),
+      expect.objectContaining({
+        path: "profiles.new-soundscape.ambienceLayers.wind.audioPaths.1",
+        message: 'Selected audio path "ambience/missing.ogg" could not be loaded by Foundry.',
+      }),
+      expect.objectContaining({
+        path: "profiles.new-soundscape.soundMoments.stinger.audioPaths.1",
+        message: "Sound moment audio paths cannot be blank.",
+      }),
+    ]));
+    expect(isAudioPathResolvableMock).toHaveBeenCalledTimes(3);
+    expect(isAudioPathResolvableMock).toHaveBeenNthCalledWith(1, "shared/audio.ogg");
+    expect(isAudioPathResolvableMock).toHaveBeenNthCalledWith(2, "music/missing.ogg");
+    expect(isAudioPathResolvableMock).toHaveBeenNthCalledWith(3, "ambience/missing.ogg");
+  });
+
   it("resolves preview from scene assignments and world default fallback", () => {
     const directProfile = createSoundscapeProfile([], "Direct Score");
     directProfile.musicPrograms["direct-score"] = {
@@ -235,7 +292,10 @@ describe("soundscape studio helpers", () => {
       expect.objectContaining({ path: "worldDefaultProfileId" }),
       expect.objectContaining({ path: "sceneAssignments.sceneA.profileId" }),
       expect.objectContaining({ path: "profiles.new-soundscape.rules.0.musicProgramId" }),
-      expect.objectContaining({ path: "profiles.new-soundscape.musicPrograms.score.audioPaths" }),
+      expect.objectContaining({
+        path: "profiles.new-soundscape.musicPrograms.score.audioPaths.0",
+        message: 'Selected audio path "music/missing.ogg" could not be loaded by Foundry.',
+      }),
       expect.objectContaining({ path: "profiles.new-soundscape.soundMoments.stinger.audioPaths" }),
     ]));
   });

--- a/src/soundscapes/soundscape-studio-helpers.ts
+++ b/src/soundscapes/soundscape-studio-helpers.ts
@@ -51,44 +51,6 @@ function cloneProfile(profile: SoundscapeProfile): SoundscapeProfile {
   return JSON.parse(JSON.stringify(profile)) as SoundscapeProfile;
 }
 
-function joinUuidList(values: string[]): string {
-  return values.join("\n");
-}
-
-function splitUuidList(value: string): string[] {
-  return value
-    .split(/\r?\n|,/)
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
-}
-
-export function getKnownPlaylistUuidSet(): Set<string> {
-  const playlists = getGame()?.playlists;
-  if (!playlists) return new Set<string>();
-
-  const uuids = new Set<string>();
-  for (const playlist of playlists) {
-    if (typeof playlist?.uuid === "string" && playlist.uuid.trim().length > 0) {
-      uuids.add(playlist.uuid.trim());
-    }
-  }
-  return uuids;
-}
-
-export function listKnownPlaylists(): Array<{ id: string; name: string; uuid: string }> {
-  const playlists = getGame()?.playlists;
-  if (!playlists) return [];
-
-  return [...playlists]
-    .map((playlist) => ({
-      id: playlist.id,
-      name: playlist.name?.trim() || "Untitled Playlist",
-      uuid: typeof playlist.uuid === "string" ? playlist.uuid.trim() : "",
-    }))
-    .filter((playlist) => playlist.uuid.length > 0)
-    .sort((left, right) => left.name.localeCompare(right.name));
-}
-
 export function listSoundscapeProfiles(snapshot: PersistentSoundscapeLibrarySnapshot): SoundscapeProfile[] {
   return Object.values(snapshot.profiles).sort((left, right) => left.name.localeCompare(right.name));
 }
@@ -220,14 +182,6 @@ export function updateStudioSceneAssignmentProfile(
     : null;
 }
 
-export function parseUuidText(value: string): string[] {
-  return splitUuidList(value);
-}
-
-export function stringifyUuidText(values: string[]): string {
-  return joinUuidList(values);
-}
-
 export function resolveSoundscapeStudioPreview(input: {
   library: PersistentSoundscapeLibrarySnapshot;
   selectedProfileId: string | null;
@@ -282,6 +236,36 @@ export async function validateSoundscapeStudioData(
     const paths = uniqueAudioPaths.get(audioPath) ?? [];
     paths.push(path);
     uniqueAudioPaths.set(audioPath, paths);
+  };
+  const validateAudioPaths = (input: {
+    profileId: string;
+    parentPath: string;
+    label: string;
+    audioPaths: string[];
+    emptyCollectionMessage: string;
+  }): void => {
+    if (input.audioPaths.length === 0) {
+      messages.push({
+        profileId: input.profileId,
+        path: `${input.parentPath}.audioPaths`,
+        message: input.emptyCollectionMessage,
+      });
+      return;
+    }
+
+    for (const [index, audioPath] of input.audioPaths.entries()) {
+      const trimmedPath = audioPath.trim();
+      const path = `${input.parentPath}.audioPaths.${index}`;
+      if (trimmedPath.length === 0) {
+        messages.push({
+          profileId: input.profileId,
+          path,
+          message: `${input.label} audio paths cannot be blank.`,
+        });
+        continue;
+      }
+      queueAssetCheck(trimmedPath, path);
+    }
   };
 
   for (const profile of profiles) {
@@ -380,16 +364,13 @@ export async function validateSoundscapeStudioData(
           message: "Music delay cannot be negative.",
         });
       }
-      if (program.audioPaths.length === 0) {
-        messages.push({
-          profileId: profile.id,
-          path: `${prefix}.audioPaths`,
-          message: "Music programs need at least one audio path.",
-        });
-      }
-      for (const audioPath of program.audioPaths) {
-        queueAssetCheck(audioPath, `${prefix}.audioPaths`);
-      }
+      validateAudioPaths({
+        profileId: profile.id,
+        parentPath: prefix,
+        label: "Music program",
+        audioPaths: program.audioPaths,
+        emptyCollectionMessage: "Music programs need at least one audio path.",
+      });
     }
 
     for (const layer of Object.values(profile.ambienceLayers)) {
@@ -415,16 +396,13 @@ export async function validateSoundscapeStudioData(
           message: "Ambience max delay must be greater than or equal to min delay.",
         });
       }
-      if (layer.audioPaths.length === 0) {
-        messages.push({
-          profileId: profile.id,
-          path: `${prefix}.audioPaths`,
-          message: "Ambience layers need at least one audio path.",
-        });
-      }
-      for (const audioPath of layer.audioPaths) {
-        queueAssetCheck(audioPath, `${prefix}.audioPaths`);
-      }
+      validateAudioPaths({
+        profileId: profile.id,
+        parentPath: prefix,
+        label: "Ambience layer",
+        audioPaths: layer.audioPaths,
+        emptyCollectionMessage: "Ambience layers need at least one audio path.",
+      });
     }
 
     for (const moment of Object.values(profile.soundMoments)) {
@@ -436,16 +414,13 @@ export async function validateSoundscapeStudioData(
           message: "Sound moments need a name.",
         });
       }
-      if (moment.audioPaths.length === 0) {
-        messages.push({
-          profileId: profile.id,
-          path: `${prefix}.audioPaths`,
-          message: "Sound moments need at least one audio path.",
-        });
-      }
-      for (const audioPath of moment.audioPaths) {
-        queueAssetCheck(audioPath, `${prefix}.audioPaths`);
-      }
+      validateAudioPaths({
+        profileId: profile.id,
+        parentPath: prefix,
+        label: "Sound moment",
+        audioPaths: moment.audioPaths,
+        emptyCollectionMessage: "Sound moments need at least one audio path.",
+      });
     }
   }
 
@@ -456,7 +431,7 @@ export async function validateSoundscapeStudioData(
     for (const path of paths) {
       messages.push({
         path,
-        message: `Referenced audio path "${audioPath}" could not be resolved.`,
+        message: `Selected audio path "${audioPath}" could not be loaded by Foundry.`,
       });
     }
   }


### PR DESCRIPTION
## Summary
- tighten soundscape studio validation around blank and unloadable audio paths with explicit indexed messages
- expand normalization coverage for ordered audio paths and format version 2 handling
- lock path-based snapshot/result fields into API, runtime, and live-controls regression tests

## Testing
- npm run test -- src/soundscapes/soundscape-live-controls-app.test.tsx src/soundscapes/soundscape-api.test.ts src/soundscapes/soundscape-studio-helpers.test.ts src/soundscapes/soundscape-normalization.test.ts src/soundscapes/soundscape-music-runtime.test.ts src/soundscapes/soundscape-ambience-runtime.test.ts
- npm run typecheck

Closes #94.